### PR TITLE
Fix Criteo Inference

### DIFF
--- a/nvtabular/inference/triton/__init__.py
+++ b/nvtabular/inference/triton/__init__.py
@@ -736,9 +736,12 @@ def _remove_columns(workflow, to_remove):
 
         if node.selector:
             for column in to_remove:
-                # TODO: Handle selector sub-groups?
-                if column in node.selector.names:
+                if column in node.selector._names:
                     node.selector._names.remove(column)
+
+                for subgroup in node.selector.subgroups:
+                    if column in subgroup._names:
+                        subgroup._names.remove(column)
 
     return workflow.fit_schema(new_schema)
 


### PR DESCRIPTION
The inference notebooks with the Criteo example were broken - and failed
to generate triton config with an in _remove_columns like ```ValueError: list.remove(x): x not in
list```. This was because the label column wa being inserted into a subgroup of the outputnode,
and wasn't getting removed from there.

Fix and add a basic unittest for _remove_columns that would have caught this.

Closes https://github.com/NVIDIA-Merlin/NVTabular/issues/1198

