### PR TITLE
Fix parquet data-transfer bug for remote storage

### DIFF
--- a/nvtabular/io/fsspec_utils.py
+++ b/nvtabular/io/fsspec_utils.py
@@ -179,8 +179,14 @@ def _get_parquet_byte_ranges(
             for c in range(row_group.num_columns):
                 column = row_group.column(c)
                 name = column.path_in_schema
-                # Skip this column if we are targeting a
-                # specific columns
+                # Skip this column if we are targeting
+                # specific columns, and this name is not
+                # in the list.
+                #
+                # Note that `column.path_in_schema` may
+                # modify the column name for list and struct
+                # columns. For example, a column named "a"
+                # may become "a.list.element"
                 split_name = name.split(".")[0]
                 if columns is None or name in columns or split_name in columns:
                     file_offset0 = column.dictionary_page_offset


### PR DESCRIPTION
Closes #1155 

The optimized fsspec logic (added in #1119), does not properly recognize list or struct-column names in the parquet metadata. This is because a column name like `"a"` may be encoded as `"a.list.element"` or `"a.field"` in the parquet metadata. The proposed fix here is to split the encoded name by `"."` when checking if the corresponding data is in the list of required column names. This means we *may* transfer data that is not desired by the user if they happen to use `"."` in their column names (with common prefixes). However, I expect this "corner case" to be uncommon.

<!--

Thank you for contributing to NVTabular :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
