### PR TITLE
Add codespell

### DIFF
--- a/.github/workflows/cpu-ci.yml
+++ b/.github/workflows/cpu-ci.yml
@@ -40,6 +40,9 @@ jobs:
     - name: Lint with isort
       run: |
         isort -c .
+    - name: Lint with codespell
+      run: |
+        codespell
     - name: Build
       run: |
         python setup.py develop --user

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,10 @@ repos:
         rev: pylint-2.7.4
         hooks:
         - id: pylint
+      - repo: https://github.com/codespell-project/codespell
+        rev: v2.1.0
+        hooks:
+        - id: codespell
       - repo: https://github.com/PyCQA/bandit
         rev: 1.7.0
         hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,7 +99,7 @@
 
 ## Breaking Changes
 
-* The API for NVTabular has been signficantly refactored, and existing code targetting the 0.3 API will need to be updated.
+* The API for NVTabular has been significantly refactored, and existing code targeting the 0.3 API will need to be updated.
 Workflows are now represented as graphs of operations, and applied using a sklearn 'transformers' style api. Read more by
 checking out the [examples](https://nvidia-merlin.github.io/NVTabular/v0.4.0/examples/index.html)
 
@@ -139,7 +139,7 @@ checking out the [examples](https://nvidia-merlin.github.io/NVTabular/v0.4.0/exa
 
 ## Bug Fixes
 
-* Fix PyTorch dataloader for compatability with deep learning examples
+* Fix PyTorch dataloader for compatibility with deep learning examples
 * Fix FillMissing operator with constant fill
 * Fix missing yaml dependency on conda install
 * Fix get_emb_sz off-by-one error

--- a/ci/ignore_codespell_words.txt
+++ b/ci/ignore_codespell_words.txt
@@ -1,0 +1,7 @@
+te
+coo
+ser
+fo
+ot
+lik
+usera

--- a/nvtabular/loader/backend.py
+++ b/nvtabular/loader/backend.py
@@ -240,7 +240,7 @@ class DataLoader:
     @property
     def _buff_len(self):
         if self.__buff_len is None:
-            # run once instead of everytime len called
+            # run once instead of every time len called
             self.__buff_len = len(self._buff)
         return self.__buff_len
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -22,3 +22,4 @@ s3fs>=2021.4
 git+https://github.com/rapidsai/asvdb.git
 graphviz>=0.16
 cpplint>=1.5
+codespell

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,3 +21,9 @@ parentdir_prefix = nvtabular-
 
 [pydocstyle]
 ignore = D100,D102,D103,D104,D105,D107,D203,D205,D211,D212,D213,D400,D401,D413,D415
+
+[codespell]
+skip = .*pb2.py,./.git,./.github,./bench,./dist,./docs/build,.*egg-info.*,versioneer.py,*.csv,*.parquet
+ignore-words = ./ci/ignore_codespell_words.txt
+count =
+quiet-level = 3

--- a/tests/unit/ops/test_ops_schema.py
+++ b/tests/unit/ops/test_ops_schema.py
@@ -197,7 +197,7 @@ def test_ops_list_vc(properties, tags, op_routine):
         schema1 = workflow_schema_out.column_schemas[column_name]
         assert "domain" in schema1.properties
         embeddings_info = schema1.properties["domain"]
-        # should always exist, represents unkown
+        # should always exist, represents unknown
         assert embeddings_info["min"] == 0
         assert embeddings_info["max"] == new_gdf[column_name]._column.elements.max() + 1
         assert "value_count" in schema1.properties


### PR DESCRIPTION
This change adds codespell as one of our linters, to both the precommit hook
and the github ci.

