### PR TITLE
Allow writing workflows to cloud storage

### DIFF
--- a/nvtabular/ops/categorify.py
+++ b/nvtabular/ops/categorify.py
@@ -1345,14 +1345,15 @@ def _hash_bucket(df, num_buckets, col, encode_type="joint"):
 
 def _copy_storage(existing_stats, existing_path, new_path, copy):
     """helper function to copy files to a new storage location"""
-    from shutil import copyfile
-
+    existing_fs = get_fs_token_paths(existing_path)[0]
+    new_fs = get_fs_token_paths(new_path)[0]
     new_locations = {}
     for column, existing_file in existing_stats.items():
         new_file = existing_file.replace(str(existing_path), str(new_path))
         if copy and new_file != existing_file:
-            os.makedirs(os.path.dirname(new_file), exist_ok=True)
-            copyfile(existing_file, new_file)
+            new_fs.makedirs(os.path.dirname(new_file), exist_ok=True)
+            with new_fs.open(new_file, "wb") as output:
+                output.write(existing_fs.open(existing_file, "rb").read())
 
         new_locations[column] = new_file
 

--- a/nvtabular/worker.py
+++ b/nvtabular/worker.py
@@ -23,7 +23,6 @@ try:
     import cudf
 except ImportError:
     cudf = None
-import fsspec
 import pyarrow as pa
 from dask.distributed import get_worker
 
@@ -83,8 +82,7 @@ def fetch_table_data(
             if reader == _lib.read_parquet:  # pylint: disable=comparison-with-callable
                 # Using cudf-backed data with "host" caching.
                 # Cache as an Arrow table.
-                with contextlib.closing(fsspec.open(path, "rb")) as f:
-                    table = reader(f, **use_kwargs)
+                table = reader(path, **use_kwargs)
                 if cudf:
                     table_cache[path] = table.to_arrow()
                 else:

--- a/nvtabular/workflow/workflow.py
+++ b/nvtabular/workflow/workflow.py
@@ -15,13 +15,13 @@
 #
 import json
 import logging
-import os
 import sys
 import time
 import warnings
 from typing import TYPE_CHECKING, Optional
 
 import cloudpickle
+import fsspec
 
 try:
     import cudf
@@ -283,7 +283,9 @@ class Workflow:
         # avoid a circular import getting the version
         from nvtabular import __version__ as nvt_version
 
-        os.makedirs(path, exist_ok=True)
+        fs = fsspec.get_fs_token_paths(path)[0]
+
+        fs.makedirs(path, exist_ok=True)
 
         # point all stat ops to store intermediate output (parquet etc) at the path
         # this lets us easily bundle
@@ -292,7 +294,7 @@ class Workflow:
 
         # generate a file of all versions used to generate this bundle
         lib = cudf if cudf else pd
-        with open(os.path.join(path, "metadata.json"), "w") as o:
+        with fs.open(fs.sep.join([path, "metadata.json"]), "w") as o:
             json.dump(
                 {
                     "versions": {
@@ -306,7 +308,7 @@ class Workflow:
             )
 
         # dump out the full workflow (graph/stats/operators etc) using cloudpickle
-        with open(os.path.join(path, "workflow.pkl"), "wb") as o:
+        with fs.open(fs.sep.join([path, "workflow.pkl"]), "wb") as o:
             cloudpickle.dump(self, o)
 
     @classmethod
@@ -327,8 +329,10 @@ class Workflow:
         # avoid a circular import getting the version
         from nvtabular import __version__ as nvt_version
 
+        fs = fsspec.get_fs_token_paths(path)[0]
+
         # check version information from the metadata blob, and warn if we have a mismatch
-        meta = json.load(open(os.path.join(path, "metadata.json")))
+        meta = json.load(fs.open(fs.sep.join([path, "metadata.json"])))
 
         def parse_version(version):
             return version.split(".")[:2]
@@ -354,7 +358,7 @@ class Workflow:
             warnings.warn(f"Loading workflow generated on {expected}")
 
         # load up the workflow object di
-        workflow = cloudpickle.load(open(os.path.join(path, "workflow.pkl"), "rb"))
+        workflow = cloudpickle.load(fs.open(fs.sep.join([path, "workflow.pkl"]), "rb"))
         workflow.client = client
 
         # we might have been copied since saving, update all the stat ops


### PR DESCRIPTION
Add support for writing workflow objects and statistics files to cloud storage
like GCS or S3 using fsspec. Also add a test that we can do this in S3.

Closes #1230

