### PR TITLE
Fix inference issues for end-to-end TF example for Transformers4Rec

### DIFF
--- a/nvtabular/inference/workflow/base.py
+++ b/nvtabular/inference/workflow/base.py
@@ -117,7 +117,7 @@ class WorkflowRunner(ABC):
                 for col in selector_columns:
                     if col in upstream_tensors:
                         to_remove.append(col)
-            for col in to_remove:
+            for col in set(to_remove):
                 selector_columns.remove(col)
 
             if selector_columns:

--- a/nvtabular/inference/workflow/base.py
+++ b/nvtabular/inference/workflow/base.py
@@ -135,9 +135,10 @@ class WorkflowRunner(ABC):
                     # we have multiple different kinds of data here (dataframe/array on cpu/gpu)
                     # we need to convert to a common format here first before concatenating.
                     op = workflow_node.op
-                    target_kind = (
-                        workflow_node.inference_supports if op else Supports.CPU_DICT_ARRAY
-                    )
+                    if op and hasattr(op, "inference_supports"):
+                        target_kind = op.inference_supports
+                    else:
+                        target_kind = Supports.CPU_DICT_ARRAY
                     # note : the 2nd convert_format call needs to be stricter in what the kind is
                     # (exact match rather than a bitmask of values)
                     tensors, kind = convert_format(tensors, kind, target_kind)


### PR DESCRIPTION
Copying the commit messages here:

> This fixes an issue in the inference code where trying to gather inputs from the input dataframe that aren't produced by the upstream (e.g. parent) nodes relied on a list of the upstream nodes' outputs, which sometimes may contain duplicate column names. When it tries to remove those from the list of input columns required by the current node, the first attempt to remove the column succeeds, but the second one fails. This fix uses a set instead of a list to avoid duplicates.

> This fixes a call to `inference_supports` (which only exists for `Workflow` nodes, not for generic graph nodes) by wrapping it with a `hasattr` check. This prevents the method from being called for generic graph operators like `ConcatColumns`.

Depended on by NVIDIA-Merlin/Transformers4Rec#341