### PR TITLE
Switch to packaging.version.Version for version checks

### DIFF
--- a/nvtabular/io/shuffle.py
+++ b/nvtabular/io/shuffle.py
@@ -15,11 +15,11 @@
 #
 import enum
 import warnings
-from distutils.version import LooseVersion
 
 import pandas as pd
+from packaging.version import Version
 
-_IGNORE_INDEX_SUPPORTED = pd.__version__ >= LooseVersion("1.3.0")
+_IGNORE_INDEX_SUPPORTED = Version(pd.__version__) >= Version("1.3.0")
 
 
 class Shuffle(enum.Enum):

--- a/nvtabular/ops/bucketize.py
+++ b/nvtabular/ops/bucketize.py
@@ -13,9 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from distutils.version import LooseVersion
-
 import numpy as np
+from packaging.version import Version
 
 from nvtabular.dispatch import DataFrameType, _array, annotate
 from nvtabular.graph.tags import Tags
@@ -49,7 +48,7 @@ class Bucketize(Operator):
         try:
             import cupy
 
-            self.use_digitize = LooseVersion(cupy.__version__) >= "8.0.0"
+            self.use_digitize = Version(cupy.__version__) >= Version("8.0.0")
         except ImportError:
             # Assume cpu-backed data (since cupy is not even installed)
             self.use_digitize = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ tqdm>=4.0
 pyarrow>=1.0
 tensorflow-metadata>=1.2.0
 protobuf>=3.0.0
+packaging

--- a/tests/unit/test_io.py
+++ b/tests/unit/test_io.py
@@ -19,7 +19,6 @@ import json
 import math
 import os
 import warnings
-from distutils.version import LooseVersion
 
 import dask
 import dask.dataframe as dd
@@ -28,6 +27,7 @@ import pandas as pd
 import pytest
 from dask.dataframe import assert_eq
 from dask.dataframe.io.demo import names as name_list
+from packaging.version import Version
 
 import nvtabular as nvt
 import nvtabular.io
@@ -42,7 +42,7 @@ dask_cudf = pytest.importorskip("dask_cudf")
 
 
 def test_validate_dataset_bad_schema(tmpdir):
-    if LooseVersion(dask.__version__) <= "2.30.0":
+    if Version(dask.__version__) <= Version("2.30.0"):
         # Older versions of Dask will not handle schema mismatch
         pytest.skip("Test requires newer version of Dask.")
 
@@ -970,7 +970,7 @@ def test_parquet_filtered_hive(tmpdir, cpu):
 
 
 @pytest.mark.skipif(
-    LooseVersion(dask.__version__) < "2021.07.1",
+    Version(dask.__version__) < Version("2021.07.1"),
     reason="Dask>=2021.07.1 required for file aggregation",
 )
 @pytest.mark.parametrize("cpu", [True, False])


### PR DESCRIPTION
distutils.version.LooseVersion is deprecated, and causes warnings like
```DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead``` . 
