### PR TITLE
[REVIEW] docs: Update URL to Criteo notebook

### DIFF
--- a/nvtabular/io/dataset.py
+++ b/nvtabular/io/dataset.py
@@ -149,7 +149,7 @@ class Dataset:
     look at this notebook_ for an example of transforming the original Criteo
     CSV dataset into a new Parquet dataset optimized for use with NVTabular.
 
-    .. _notebook: https://github.com/NVIDIA/NVTabular/blob/main/examples/optimize_criteo.ipynb
+    .. _notebook: https://github.com/NVIDIA-Merlin/NVTabular/blob/main/examples/scaling-criteo/01-Download-Convert.ipynb # noqa
 
 
     Parameters


### PR DESCRIPTION
I'm proposing an update to a broken link.  I speculated what the replacement link should be, so please check my choice.

No tests were added, but tests were run locally.  The ` test_s3_dataset[parquet]` failed.
