### PR TITLE
Pin `merlin-core` to a specific commit to avoid breaking changes

### DIFF
--- a/ci/build_and_test.sh
+++ b/ci/build_and_test.sh
@@ -9,7 +9,7 @@ cd $nvt_directory
 echo "Installing NVTabular"
 python -m pip install --user --upgrade pip setuptools wheel pybind11 numpy==1.20.3 setuptools==59.4.0
 python -m pip uninstall nvtabular -y
-python -m pip install --user --upgrade merlin-core@git+https://github.com/NVIDIA-Merlin/core.git@2c980f7f949e378f6fc8a8bee4c3a7dc9d021020
+python -m pip install --user --upgrade merlin-core@git+https://github.com/NVIDIA-Merlin/core.git@eb24f97ab9fd0081d8082f9472f31ace4213e781
 python setup.py develop --user --no-deps
 
 # following checks requirement requirements-dev.txt to be installed

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ pyarrow>=1.0
 tensorflow-metadata>=1.2.0
 protobuf>=3.0.0
 packaging
-merlin-core@git+https://github.com/NVIDIA-Merlin/core.git@2c980f7f949e378f6fc8a8bee4c3a7dc9d021020
+merlin-core@git+https://github.com/NVIDIA-Merlin/core.git@eb24f97ab9fd0081d8082f9472f31ace4213e781
 


### PR DESCRIPTION
There are some upcoming changes to the package names in merlin-core (e.g. graph->dag) that would break the tests in merlin-models if we continued depending directly on the latest commit in merlin-core. Pinning the version to a specific commit allows us to bump the version here in the same PR that propagates upstream changes from merlin-core without breaking the tests/CI on everyone else's PRs.
