### PR TITLE
Assume 'merlin' is a first party package for isort

### DIFF
--- a/nvtabular/framework_utils/tensorflow/feature_column_utils.py
+++ b/nvtabular/framework_utils/tensorflow/feature_column_utils.py
@@ -17,10 +17,10 @@ import warnings
 
 import pandas as pd
 import tensorflow as tf
-from merlin.dag import ColumnSelector
 from tensorflow.python.feature_column import feature_column_v2 as fc
 
 import nvtabular as nvt
+from merlin.dag import ColumnSelector
 from nvtabular.ops import Bucketize, Categorify, HashBucket, HashedCross, Rename
 
 

--- a/nvtabular/inference/graph/ensemble.py
+++ b/nvtabular/inference/graph/ensemble.py
@@ -21,9 +21,9 @@ from merlin.dag import postorder_iter_nodes
 os.environ["PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION"] = "python"
 
 from google.protobuf import text_format  # noqa
-from merlin.dag import Graph  # noqa
 
 import nvtabular.inference.triton.model_config_pb2 as model_config  # noqa
+from merlin.dag import Graph  # noqa
 from nvtabular.inference.triton.ensemble import _convert_dtype  # noqa
 
 

--- a/nvtabular/inference/graph/ops/operator.py
+++ b/nvtabular/inference/graph/ops/operator.py
@@ -4,9 +4,8 @@ import pathlib
 from abc import abstractclassmethod, abstractmethod
 from shutil import copyfile
 
-from merlin.dag import BaseOperator
-
 import nvtabular as nvt
+from merlin.dag import BaseOperator
 
 # this needs to be before any modules that import protobuf
 os.environ["PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION"] = "python"

--- a/nvtabular/inference/graph/ops/tensorflow.py
+++ b/nvtabular/inference/graph/ops/tensorflow.py
@@ -19,7 +19,6 @@ from sys import version
 
 from merlin.dag import ColumnSelector
 from merlin.schema import ColumnSchema, Schema
-
 from nvtabular.inference.graph.ops.operator import InferenceOperator
 from nvtabular.inference.triton.ensemble import export_tensorflow_model
 

--- a/nvtabular/inference/graph/ops/workflow.py
+++ b/nvtabular/inference/graph/ops/workflow.py
@@ -17,7 +17,6 @@ import pathlib
 
 from merlin.dag import ColumnSelector
 from merlin.schema import Schema
-
 from nvtabular.inference.graph.ops.operator import InferenceOperator
 from nvtabular.inference.triton.ensemble import _generate_nvtabular_config
 

--- a/nvtabular/inference/triton/data_conversions.py
+++ b/nvtabular/inference/triton/data_conversions.py
@@ -34,8 +34,8 @@ except ImportError:
 
 import numpy as np
 import pandas as pd
-from merlin.dag import Supports
 
+from merlin.dag import Supports
 from nvtabular.dispatch import build_cudf_list_column, is_list_dtype
 
 

--- a/nvtabular/inference/triton/ensemble.py
+++ b/nvtabular/inference/triton/ensemble.py
@@ -26,9 +26,9 @@ from nvtabular import ColumnSelector
 os.environ["PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION"] = "python"
 
 from google.protobuf import text_format  # noqa
-from merlin.schema import Tags  # noqa
 
 import nvtabular.inference.triton.model_config_pb2 as model_config  # noqa
+from merlin.schema import Tags  # noqa
 from nvtabular.dispatch import is_string_dtype  # noqa
 
 

--- a/nvtabular/inference/workflow/base.py
+++ b/nvtabular/inference/workflow/base.py
@@ -30,9 +30,9 @@ import logging
 from abc import ABC, abstractmethod
 
 import numpy as np
+
 from merlin.dag import Supports
 from merlin.schema import Tags
-
 from nvtabular import ColumnSelector
 from nvtabular.dispatch import concat_columns
 from nvtabular.inference.triton.data_conversions import convert_format

--- a/nvtabular/loader/backend.py
+++ b/nvtabular/loader/backend.py
@@ -28,7 +28,6 @@ except ImportError:
     cp = np
 
 from merlin.schema import Tags
-
 from nvtabular.dispatch import (
     HAS_GPU,
     annotate,

--- a/nvtabular/loader/tensorflow.py
+++ b/nvtabular/loader/tensorflow.py
@@ -19,8 +19,8 @@ import os
 
 import dask.dataframe as dd
 import numpy as np
-from merlin.schema import Tags
 
+from merlin.schema import Tags
 from nvtabular.dispatch import HAS_GPU
 from nvtabular.loader.backend import DataLoader
 from nvtabular.loader.tf_utils import configure_tensorflow, get_dataset_schema_from_feature_columns

--- a/nvtabular/ops/bucketize.py
+++ b/nvtabular/ops/bucketize.py
@@ -14,9 +14,9 @@
 # limitations under the License.
 
 import numpy as np
-from merlin.schema import Tags
 from packaging.version import Version
 
+from merlin.schema import Tags
 from nvtabular.dispatch import DataFrameType, annotate, array
 
 from .operator import ColumnSelector, Operator

--- a/nvtabular/ops/categorify.py
+++ b/nvtabular/ops/categorify.py
@@ -33,9 +33,9 @@ from dask.delayed import Delayed
 from dask.highlevelgraph import HighLevelGraph
 from dask.utils import parse_bytes
 from fsspec.core import get_fs_token_paths
-from merlin.schema import Schema, Tags
 from pyarrow import parquet as pq
 
+from merlin.schema import Schema, Tags
 from nvtabular import dispatch
 from nvtabular.dispatch import DataFrameType, annotate, is_cpu_object, nullable_series
 from nvtabular.utils import device_mem_size, run_on_worker

--- a/nvtabular/ops/column_similarity.py
+++ b/nvtabular/ops/column_similarity.py
@@ -30,7 +30,6 @@ except ImportError:
     from scipy.sparse import coo_matrix
 
 from merlin.schema import Schema, Tags
-
 from nvtabular.dispatch import DataFrameType, annotate
 
 from .operator import ColumnSelector, Operator

--- a/nvtabular/ops/difference_lag.py
+++ b/nvtabular/ops/difference_lag.py
@@ -14,8 +14,8 @@
 # limitations under the License.
 #
 import numpy
-from merlin.schema import Tags
 
+from merlin.schema import Tags
 from nvtabular.dispatch import DataFrameType, annotate, is_dataframe_object
 
 from .operator import ColumnSelector, Operator

--- a/nvtabular/ops/groupby.py
+++ b/nvtabular/ops/groupby.py
@@ -14,8 +14,8 @@
 # limitations under the License.
 import numpy
 from dask.dataframe.utils import meta_nonempty
-from merlin.schema import Schema
 
+from merlin.schema import Schema
 from nvtabular.dispatch import DataFrameType, annotate
 
 from .operator import ColumnSelector, Operator

--- a/nvtabular/ops/hash_bucket.py
+++ b/nvtabular/ops/hash_bucket.py
@@ -16,6 +16,7 @@
 from typing import Dict, Union
 
 import numpy
+
 from merlin.schema import Tags
 
 from ..dispatch import DataFrameType, annotate, encode_list_column, hash_series, is_list_dtype

--- a/nvtabular/ops/join_external.py
+++ b/nvtabular/ops/join_external.py
@@ -22,8 +22,8 @@ except ImportError:
 
 import dask.dataframe as dd
 import pandas as pd
-from merlin.schema import Schema
 
+from merlin.schema import Schema
 from nvtabular.dispatch import (
     DataFrameType,
     ExtData,

--- a/nvtabular/ops/join_groupby.py
+++ b/nvtabular/ops/join_groupby.py
@@ -18,9 +18,9 @@ import dask.dataframe as dd
 import numpy as np
 import pandas as pd
 from dask.delayed import Delayed
-from merlin.schema import Schema
 
 import nvtabular as nvt
+from merlin.schema import Schema
 from nvtabular.dispatch import DataFrameType, arange, concat_columns, read_parquet_dispatch
 
 from . import categorify as nvt_cat

--- a/nvtabular/ops/list_slice.py
+++ b/nvtabular/ops/list_slice.py
@@ -22,7 +22,6 @@ except ImportError:
     cp = None
 
 from merlin.schema import Tags
-
 from nvtabular.dispatch import DataFrameType, annotate, build_cudf_list_column, is_cpu_object
 
 from .operator import ColumnSelector, Operator

--- a/nvtabular/ops/logop.py
+++ b/nvtabular/ops/logop.py
@@ -14,8 +14,8 @@
 # limitations under the License.
 #
 import numpy as np
-from merlin.schema import Tags
 
+from merlin.schema import Tags
 from nvtabular.dispatch import (
     DataFrameType,
     annotate,

--- a/nvtabular/ops/normalize.py
+++ b/nvtabular/ops/normalize.py
@@ -15,6 +15,7 @@
 #
 import dask.dataframe as dd
 import numpy
+
 from merlin.dag import Supports
 from merlin.schema import Tags
 

--- a/nvtabular/ops/operator.py
+++ b/nvtabular/ops/operator.py
@@ -17,9 +17,8 @@ from __future__ import annotations
 
 from typing import Optional
 
-from merlin.dag import BaseOperator, ColumnSelector
-
 import nvtabular as nvt
+from merlin.dag import BaseOperator, ColumnSelector
 from nvtabular.dispatch import DataFrameType
 
 

--- a/nvtabular/ops/reduce_dtype_size.py
+++ b/nvtabular/ops/reduce_dtype_size.py
@@ -15,6 +15,7 @@
 #
 import dask.dataframe as dd
 import numpy as np
+
 from merlin.schema import Schema
 
 from ..dispatch import DataFrameType, annotate

--- a/nvtabular/ops/target_encoding.py
+++ b/nvtabular/ops/target_encoding.py
@@ -16,9 +16,9 @@
 import dask.dataframe as dd
 import numpy as np
 from dask.delayed import Delayed
+
 from merlin.dag import Node
 from merlin.schema import Schema, Tags
-
 from nvtabular.dispatch import (
     DataFrameType,
     arange,

--- a/nvtabular/tools/data_gen.py
+++ b/nvtabular/tools/data_gen.py
@@ -31,10 +31,10 @@ try:
 except ImportError:
     cudf = pd
 
-from merlin.io import Dataset
 from scipy import stats
 from scipy.stats import powerlaw, uniform
 
+from merlin.io import Dataset
 from nvtabular.dispatch import (
     HAS_GPU,
     concat,

--- a/nvtabular/tools/dataset_inspector.py
+++ b/nvtabular/tools/dataset_inspector.py
@@ -18,8 +18,8 @@ import json
 
 import fsspec
 import numpy as np
-from merlin.dag import ColumnSelector
 
+from merlin.dag import ColumnSelector
 from nvtabular.ops import DataStats
 from nvtabular.utils import set_client_deprecated
 from nvtabular.workflow import Workflow

--- a/nvtabular/workflow/node.py
+++ b/nvtabular/workflow/node.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 #
 from merlin.dag import Node
-
 from nvtabular.ops import LambdaOp, Operator
 
 

--- a/nvtabular/workflow/workflow.py
+++ b/nvtabular/workflow/workflow.py
@@ -30,9 +30,9 @@ except ImportError:
 import dask
 import pandas as pd
 from dask.core import flatten
-from merlin.dag import Graph
 
 import nvtabular
+from merlin.dag import Graph
 from nvtabular.dispatch import concat_columns, is_list_dtype, list_val_dtype
 from nvtabular.io import Dataset
 from nvtabular.ops import StatOperator

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ line_length = 100
 balanced_wrapping = true
 indent = "    "
 known_third_party = ["cudf", "cupy", "dask", "dask_cuda", "dask_cudf", "numba", "numpy", "pytest", "torch", "rmm", "tensorflow"]
+known_first_party = ["merlin"]
 skip = ["build",".eggs", "examples/criteo_benchmark.py", "examples/dataloader_bench.py", "model_config_pb2.py"]
 
 [tool.pytest.ini_options]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,10 +53,10 @@ except ImportError:
 import pytest
 from asvdb import ASVDb, BenchmarkInfo, utils
 from dask.distributed import Client, LocalCluster
-from merlin.dag.node import iter_nodes
 from numba import cuda
 
 import nvtabular
+from merlin.dag.node import iter_nodes
 
 allcols_csv = ["timestamp", "id", "label", "name-string", "x", "y", "z"]
 mycols_csv = ["name-string", "id", "label", "x", "y"]

--- a/tests/unit/framework_utils/test_tf_feature_columns.py
+++ b/tests/unit/framework_utils/test_tf_feature_columns.py
@@ -1,4 +1,5 @@
 import pytest
+
 from merlin.schema import Schema
 
 tf = pytest.importorskip("tensorflow")

--- a/tests/unit/inference/test_ensemble.py
+++ b/tests/unit/inference/test_ensemble.py
@@ -21,11 +21,11 @@ import pytest
 os.environ["PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION"] = "python"
 
 from google.protobuf import text_format  # noqa
-from merlin.core.dispatch import make_df  # noqa
-from merlin.schema import Tags  # noqa
 
 import nvtabular as nvt  # noqa
 import nvtabular.ops as wf_ops  # noqa
+from merlin.core.dispatch import make_df  # noqa
+from merlin.schema import Tags  # noqa
 
 loader_tf_utils = pytest.importorskip("nvtabular.loader.tf_utils")
 

--- a/tests/unit/inference/test_graph.py
+++ b/tests/unit/inference/test_graph.py
@@ -1,8 +1,8 @@
 import pytest
-from merlin.schema import Schema
 
 import nvtabular as nvt
 import nvtabular.ops as wf_ops
+from merlin.schema import Schema
 
 ensemble = pytest.importorskip("nvtabular.inference.graph.ensemble")
 workflow_op = pytest.importorskip("nvtabular.inference.graph.ops.workflow")

--- a/tests/unit/inference/test_inference_ops.py
+++ b/tests/unit/inference/test_inference_ops.py
@@ -22,10 +22,10 @@ import pytest
 os.environ["PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION"] = "python"
 
 from google.protobuf import text_format  # noqa
-from merlin.schema import Schema  # noqa
 
 import nvtabular as nvt  # noqa
 import nvtabular.ops as wf_ops  # noqa
+from merlin.schema import Schema  # noqa
 
 ensemble = pytest.importorskip("nvtabular.inference.graph.ensemble")
 model_config = pytest.importorskip("nvtabular.inference.triton.model_config_pb2")

--- a/tests/unit/inference/test_op_runner.py
+++ b/tests/unit/inference/test_op_runner.py
@@ -3,11 +3,11 @@ import os
 
 import numpy as np
 import pytest
-from merlin.dag import Graph
-from merlin.schema import Tags
 
 import nvtabular as nvt
 import nvtabular.ops as wf_ops
+from merlin.dag import Graph
+from merlin.schema import Tags
 from tests.unit.inference.inf_test_ops import PlusTwoOp
 
 op_runner = pytest.importorskip("nvtabular.inference.graph.op_runner")

--- a/tests/unit/loader/test_torch_dataloader.py
+++ b/tests/unit/loader/test_torch_dataloader.py
@@ -21,6 +21,7 @@ import subprocess
 import time
 
 import pyarrow as pa
+
 from merlin.core.dispatch import HAS_GPU, make_df
 
 try:

--- a/tests/unit/ops/test_categorify.py
+++ b/tests/unit/ops/test_categorify.py
@@ -19,9 +19,9 @@ import random
 import numpy as np
 import pandas as pd
 import pytest
-from merlin.core.dispatch import make_df
 
 import nvtabular as nvt
+from merlin.core.dispatch import make_df
 from nvtabular import ColumnSelector, dispatch, ops
 from nvtabular.ops.categorify import get_embedding_sizes
 

--- a/tests/unit/ops/test_groupyby.py
+++ b/tests/unit/ops/test_groupyby.py
@@ -17,10 +17,10 @@ import dask.dataframe as dd
 import numpy as np
 import pandas as pd
 import pytest
-from merlin.core.dispatch import make_df
 
 import nvtabular as nvt
 import nvtabular.io
+from merlin.core.dispatch import make_df
 from nvtabular import ColumnSelector, Schema, Workflow, ops
 
 try:

--- a/tests/unit/ops/test_lambda.py
+++ b/tests/unit/ops/test_lambda.py
@@ -18,11 +18,11 @@ import numpy as np
 import pandas as pd
 import pytest
 from dask.dataframe import assert_eq as assert_eq_dd
-from merlin.schema import Tags, TagSet
 from pandas.api.types import is_integer_dtype
 
 import nvtabular as nvt
 import nvtabular.io
+from merlin.schema import Tags, TagSet
 from nvtabular import ColumnSelector, ops
 
 try:

--- a/tests/unit/ops/test_ops.py
+++ b/tests/unit/ops/test_ops.py
@@ -18,10 +18,10 @@ import copy
 import numpy as np
 import pandas as pd
 import pytest
-from merlin.schema import Tags, TagSet
 
 import nvtabular as nvt
 import nvtabular.io
+from merlin.schema import Tags, TagSet
 from nvtabular import ColumnSelector, dispatch, ops
 from tests.conftest import assert_eq, mycols_csv, mycols_pq
 

--- a/tests/unit/test_tf4rec.py
+++ b/tests/unit/test_tf4rec.py
@@ -5,9 +5,8 @@ try:
 except ImportError:
     from dask.dataframe import to_datetime
 
-from merlin.core.dispatch import make_df
-
 import nvtabular as nvt
+from merlin.core.dispatch import make_df
 from nvtabular import ColumnSelector
 
 NUM_ROWS = 10000

--- a/tests/unit/test_triton_inference.py
+++ b/tests/unit/test_triton_inference.py
@@ -8,10 +8,10 @@ from distutils.spawn import find_executable
 import numpy as np
 import pandas as pd
 import pytest
-from merlin.dag import Supports
 
 import nvtabular as nvt
 import nvtabular.ops as ops
+from merlin.dag import Supports
 from nvtabular import ColumnSelector
 from nvtabular.dispatch import HAS_GPU, hash_series, make_df
 from tests.conftest import assert_eq

--- a/tests/unit/workflow/test_workflow.py
+++ b/tests/unit/workflow/test_workflow.py
@@ -28,12 +28,12 @@ except ImportError:
 
 import numpy as np
 import pytest
-from merlin.core.dispatch import HAS_GPU, make_df
-from merlin.dag import ColumnSelector, postorder_iter_nodes
-from merlin.schema import Schema, Tags
 from pandas.api.types import is_integer_dtype
 
 import nvtabular as nvt
+from merlin.core.dispatch import HAS_GPU, make_df
+from merlin.dag import ColumnSelector, postorder_iter_nodes
+from merlin.schema import Schema, Tags
 from nvtabular import Dataset, Workflow, ops
 from nvtabular.utils import set_dask_client
 from tests.conftest import assert_eq, get_cats, mycols_csv

--- a/tests/unit/workflow/test_workflow_chaining.py
+++ b/tests/unit/workflow/test_workflow_chaining.py
@@ -16,9 +16,9 @@
 
 
 import numpy as np
-from merlin.core.dispatch import make_df
 
 import nvtabular as nvt
+from merlin.core.dispatch import make_df
 from nvtabular import Dataset, Workflow, ops
 from nvtabular.dispatch import HAS_GPU
 

--- a/tests/unit/workflow/test_workflow_node.py
+++ b/tests/unit/workflow/test_workflow_node.py
@@ -1,8 +1,8 @@
 import numpy as np
 import pytest
+
 from merlin.dag import ColumnSelector
 from merlin.schema import Schema
-
 from nvtabular import Dataset, Workflow, WorkflowNode, dispatch
 from nvtabular.ops import (
     Categorify,

--- a/tests/unit/workflow/test_workflow_ops.py
+++ b/tests/unit/workflow/test_workflow_ops.py
@@ -15,7 +15,6 @@
 #
 
 from merlin.dag import ops as graph_ops
-
 from nvtabular import ops as workflow_ops
 
 

--- a/tests/unit/workflow/test_workflow_schemas.py
+++ b/tests/unit/workflow/test_workflow_schemas.py
@@ -16,10 +16,10 @@
 import glob
 
 import pytest
-from merlin.dag import ColumnSelector
-from merlin.schema import ColumnSchema, Schema, Tags
 
 import nvtabular
+from merlin.dag import ColumnSelector
+from merlin.schema import ColumnSchema, Schema, Tags
 from nvtabular import Dataset, Workflow, ops
 
 


### PR DESCRIPTION
Rather than have things like 'merlin.schema' appear with the 3rd party imports, include with the first party imports

Based on @benfred's NVIDIA-Merlin/models#216