### PR TITLE
Handle aiobotocore v2.0+ in test_s3

### DIFF
--- a/ci/build_and_test.sh
+++ b/ci/build_and_test.sh
@@ -9,7 +9,7 @@ cd $nvt_directory
 echo "Installing NVTabular"
 python -m pip install --user --upgrade pip setuptools wheel pybind11 numpy==1.20.3 setuptools==59.4.0
 python -m pip uninstall nvtabular -y
-python -m pip install --user --upgrade --no-cache-dir merlin-core
+python -m pip install --user --upgrade --no-cache-dir merlin-core@merlin-core@git+https://github.com/NVIDIA-Merlin/core.git
 python setup.py develop --user --no-deps
 
 # following checks requirement requirements-dev.txt to be installed

--- a/ci/build_and_test.sh
+++ b/ci/build_and_test.sh
@@ -9,7 +9,7 @@ cd $nvt_directory
 echo "Installing NVTabular"
 python -m pip install --user --upgrade pip setuptools wheel pybind11 numpy==1.20.3 setuptools==59.4.0
 python -m pip uninstall nvtabular -y
-python -m pip install --user --upgrade --no-cache-dir merlin-core@merlin-core@git+https://github.com/NVIDIA-Merlin/core.git
+python -m pip install --user --upgrade --no-cache-dir merlin-core@git+https://github.com/NVIDIA-Merlin/core.git
 python setup.py develop --user --no-deps
 
 # following checks requirement requirements-dev.txt to be installed

--- a/tests/unit/test_s3.py
+++ b/tests/unit/test_s3.py
@@ -19,6 +19,7 @@ from io import BytesIO
 
 import pytest
 from dask.dataframe.io.parquet.core import create_metadata_file
+from packaging.version import Version
 
 import nvtabular as nvt
 from nvtabular import ops
@@ -52,10 +53,16 @@ def patch_aiobotocore(s3so):
             kwargs["endpoint_url"] = s3so["client_kwargs"]["endpoint_url"]
         return create_client(*args, **kwargs)
 
-    create_client = aiobotocore.AioSession.create_client
-    aiobotocore.AioSession.create_client = patched_create_client
+    # AioSession lives in different modules of AioBotocore depending on the version
+    if Version(aiobotocore.__version__) >= Version("2.0.0"):
+        session_module = aiobotocore.session
+    else:
+        session_module = aiobotocore
+
+    create_client = session_module.AioSession.create_client
+    session_module.AioSession.create_client = patched_create_client
     yield
-    aiobotocore.AioSession.create_client = create_client
+    session_module.AioSession.create_client = create_client
 
 
 @pytest.mark.parametrize("engine", ["parquet", "csv"])


### PR DESCRIPTION
test_s3 was failing with newer versions of aiobotocore, since the
AioSession object was moved. Fix.
