### PR TITLE
Add intersphinx mappings for merlin.core

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -231,6 +231,7 @@ intersphinx_mapping = {
     "cudf": ("https://docs.rapids.ai/api/cudf/stable/", None),
     "distributed": ("https://distributed.dask.org/en/latest/", None),
     "torch": ("https://pytorch.org/docs/stable/", None),
+    "merlin-core": ("https://nvidia-merlin.github.io/core/", None),
 }
 
 autodoc_inherit_docstrings = False


### PR DESCRIPTION
Adds intersphinx mappings for merlin.core package. This lets us
click on 'merlin.io.Dataset' types in the generated workflow
documentation, and have the link take you to the doc pages for
merlin-core

