### PR TITLE
Remove imports to deprecated modules

### DIFF
--- a/nvtabular/__init__.py
+++ b/nvtabular/__init__.py
@@ -15,10 +15,14 @@
 #
 import warnings
 
+# this is to mimic the previous API, but all of these should probably be removed
+import merlin.dag as graph  # noqa
+from merlin import io
+from merlin.core import dispatch, utils  # noqa
 from merlin.dag import ColumnSelector
 from merlin.schema import ColumnSchema, Schema
 
-from . import graph, io, utils, workflow  # noqa
+from . import workflow  # noqa
 from ._version import get_versions
 
 # suppress some warnings with cudf warning about column ordering with dlpack

--- a/nvtabular/loader/tf_utils.py
+++ b/nvtabular/loader/tf_utils.py
@@ -22,8 +22,7 @@ from packaging import version
 from tensorflow.python.feature_column import feature_column_v2 as fc
 
 from merlin.core.dispatch import HAS_GPU
-
-from ..utils import device_mem_size
+from merlin.core.utils import device_mem_size
 
 
 def configure_tensorflow(memory_allocation=None, device=None):

--- a/nvtabular/ops/categorify.py
+++ b/nvtabular/ops/categorify.py
@@ -35,11 +35,11 @@ from dask.utils import parse_bytes
 from fsspec.core import get_fs_token_paths
 from pyarrow import parquet as pq
 
+from merlin.core import dispatch
 from merlin.core.dispatch import DataFrameType, annotate, is_cpu_object, nullable_series
 from merlin.core.utils import device_mem_size, run_on_worker
 from merlin.core.worker import fetch_table_data, get_worker_cache
 from merlin.schema import Schema, Tags
-from nvtabular import dispatch
 
 from .operator import ColumnSelector, Operator
 from .stat_operator import StatOperator

--- a/nvtabular/ops/drop_low_cardinality.py
+++ b/nvtabular/ops/drop_low_cardinality.py
@@ -13,9 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from merlin.core.dispatch import DataFrameType, annotate
 from merlin.schema import Schema, Tags
 
-from ..dispatch import DataFrameType, annotate
 from .operator import ColumnSelector, Operator
 
 

--- a/nvtabular/ops/hash_bucket.py
+++ b/nvtabular/ops/hash_bucket.py
@@ -17,9 +17,15 @@ from typing import Dict, Union
 
 import numpy
 
+from merlin.core.dispatch import (
+    DataFrameType,
+    annotate,
+    encode_list_column,
+    hash_series,
+    is_list_dtype,
+)
 from merlin.schema import Tags
 
-from ..dispatch import DataFrameType, annotate, encode_list_column, hash_series, is_list_dtype
 from .categorify import _emb_sz_rule
 from .operator import ColumnSelector, Operator
 

--- a/nvtabular/ops/lambdaop.py
+++ b/nvtabular/ops/lambdaop.py
@@ -15,7 +15,8 @@
 #
 from inspect import getsourcelines, signature
 
-from ..dispatch import DataFrameType, annotate
+from merlin.core.dispatch import DataFrameType, annotate
+
 from .operator import ColumnSelector, Operator
 
 

--- a/nvtabular/ops/normalize.py
+++ b/nvtabular/ops/normalize.py
@@ -16,16 +16,16 @@
 import dask.dataframe as dd
 import numpy
 
-from merlin.dag import Supports
-from merlin.schema import Tags
-
-from ..dispatch import (
+from merlin.core.dispatch import (
     DataFrameType,
     annotate,
     encode_list_column,
     flatten_list_column_values,
     is_list_dtype,
 )
+from merlin.dag import Supports
+from merlin.schema import Tags
+
 from .moments import _custom_moments
 from .operator import ColumnSelector, Operator
 from .stat_operator import StatOperator

--- a/nvtabular/ops/reduce_dtype_size.py
+++ b/nvtabular/ops/reduce_dtype_size.py
@@ -16,9 +16,9 @@
 import dask.dataframe as dd
 import numpy as np
 
+from merlin.core.dispatch import DataFrameType, annotate
 from merlin.schema import Schema
 
-from ..dispatch import DataFrameType, annotate
 from .operator import ColumnSelector, Operator
 from .stat_operator import StatOperator
 

--- a/nvtabular/ops/rename.py
+++ b/nvtabular/ops/rename.py
@@ -13,7 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from ..dispatch import DataFrameType
+from merlin.core.dispatch import DataFrameType
+
 from .operator import ColumnSelector, Operator
 
 

--- a/nvtabular/tools/data_gen.py
+++ b/nvtabular/tools/data_gen.py
@@ -43,9 +43,8 @@ from merlin.core.dispatch import (
     make_series,
     pull_apart_list,
 )
+from merlin.core.utils import device_mem_size
 from merlin.io import Dataset
-
-from ..utils import device_mem_size
 
 
 class UniformDistro:

--- a/tests/unit/loader/test_torch_dataloader.py
+++ b/tests/unit/loader/test_torch_dataloader.py
@@ -40,6 +40,7 @@ import pytest
 
 import nvtabular as nvt
 import nvtabular.tools.data_gen as datagen
+from merlin.core import dispatch
 from merlin.io import Dataset
 from nvtabular import ColumnSelector, ops
 from tests.conftest import assert_eq, mycols_csv, mycols_pq
@@ -110,7 +111,7 @@ def test_torch_drp_reset(tmpdir, batch_size, drop_last, num_rows):
         if idx < all_len:
             for col in df_cols:
                 if col in chunk[0].keys():
-                    if nvt.dispatch.HAS_GPU:
+                    if dispatch.HAS_GPU:
                         assert (list(chunk[0][col].cpu().numpy()) == df[col].values_host).all()
                     else:
                         assert (list(chunk[0][col].cpu().numpy()) == df[col].values).all()
@@ -126,7 +127,7 @@ def test_torch_drp_reset(tmpdir, batch_size, drop_last, num_rows):
 def test_gpu_file_iterator_ds(df, dataset, batch, engine):
     df_itr = make_df({})
     for data_gd in dataset.to_iter(columns=mycols_csv):
-        df_itr = nvt.dispatch.concat([df_itr, data_gd], axis=0) if df_itr is not None else data_gd
+        df_itr = dispatch.concat([df_itr, data_gd], axis=0) if df_itr is not None else data_gd
 
     assert_eq(df_itr.reset_index(drop=True), df.reset_index(drop=True))
 

--- a/tests/unit/ops/test_categorify.py
+++ b/tests/unit/ops/test_categorify.py
@@ -21,8 +21,9 @@ import pandas as pd
 import pytest
 
 import nvtabular as nvt
+from merlin.core import dispatch
 from merlin.core.dispatch import make_df
-from nvtabular import ColumnSelector, dispatch, ops
+from nvtabular import ColumnSelector, ops
 from nvtabular.ops.categorify import get_embedding_sizes
 
 try:

--- a/tests/unit/ops/test_hash_bucket.py
+++ b/tests/unit/ops/test_hash_bucket.py
@@ -17,8 +17,9 @@ import numpy as np
 import pytest
 
 import nvtabular as nvt
+from merlin.core import dispatch
 from merlin.core.dispatch import HAS_GPU
-from nvtabular import dispatch, ops
+from nvtabular import ops
 
 if HAS_GPU:
     _CPU = [True, False]

--- a/tests/unit/ops/test_normalize.py
+++ b/tests/unit/ops/test_normalize.py
@@ -20,8 +20,9 @@ import pandas as pd
 import pytest
 
 import nvtabular as nvt
+from merlin.core import dispatch
 from merlin.core.dispatch import HAS_GPU, flatten_list_column, flatten_list_column_values
-from nvtabular import ColumnSelector, dispatch, ops
+from nvtabular import ColumnSelector, ops
 from tests.conftest import assert_eq
 
 if HAS_GPU:

--- a/tests/unit/ops/test_ops.py
+++ b/tests/unit/ops/test_ops.py
@@ -20,8 +20,9 @@ import pandas as pd
 import pytest
 
 import nvtabular as nvt
+from merlin.core import dispatch
 from merlin.schema import Tags, TagSet
-from nvtabular import ColumnSelector, dispatch, ops
+from nvtabular import ColumnSelector, ops
 from tests.conftest import assert_eq, mycols_csv, mycols_pq
 
 try:

--- a/tests/unit/ops/test_ops_schema.py
+++ b/tests/unit/ops/test_ops_schema.py
@@ -2,8 +2,9 @@ import numpy as np
 import pytest
 
 import nvtabular as nvt
+from merlin.core import dispatch
 from merlin.core.dispatch import HAS_GPU
-from nvtabular import ColumnSchema, ColumnSelector, Schema, dispatch, ops
+from nvtabular import ColumnSchema, ColumnSelector, Schema, ops
 
 
 @pytest.mark.parametrize("properties", [{}, {"p1": "1"}])
@@ -219,7 +220,7 @@ def test_ops_list_vc(properties, tags, op_routine):
         if HAS_GPU:
             assert embeddings_info["max"] == new_gdf[column_name]._column.elements.max() + 1
         else:
-            list_vals = nvt.dispatch.pull_apart_list(new_gdf[column_name])[0]
+            list_vals = dispatch.pull_apart_list(new_gdf[column_name])[0]
             assert embeddings_info["max"] == list_vals.max() + 1
         assert "value_count" in schema1.properties
         val_c = schema1.properties["value_count"]

--- a/tests/unit/ops/test_target_encode.py
+++ b/tests/unit/ops/test_target_encode.py
@@ -22,7 +22,8 @@ import pandas as pd
 import pytest
 
 import nvtabular as nvt
-from nvtabular import ColumnSelector, dispatch, ops
+from merlin.core import dispatch
+from nvtabular import ColumnSelector, ops
 from tests.conftest import assert_eq
 
 try:

--- a/tests/unit/test_s3.py
+++ b/tests/unit/test_s3.py
@@ -22,6 +22,7 @@ from dask.dataframe.io.parquet.core import create_metadata_file
 from packaging.version import Version
 
 import nvtabular as nvt
+from merlin.core import dispatch
 from nvtabular import ops
 from tests.conftest import assert_eq, mycols_csv, mycols_pq
 
@@ -100,7 +101,7 @@ def test_s3_dataset(s3_base, s3so, paths, datasets, engine, df, patch_aiobotocor
 
         # Check that the iteration API works
         columns = mycols_pq if engine == "parquet" else mycols_csv
-        gdf = nvt.dispatch.concat(list(dataset.to_iter()))[columns]
+        gdf = dispatch.concat(list(dataset.to_iter()))[columns]
         assert_eq(gdf.reset_index(drop=True), df.reset_index(drop=True))
 
         cat_names = ["name-cat", "name-string"] if engine == "parquet" else ["name-string"]

--- a/tests/unit/workflow/test_workflow.py
+++ b/tests/unit/workflow/test_workflow.py
@@ -31,6 +31,7 @@ import pytest
 from pandas.api.types import is_integer_dtype
 
 import nvtabular as nvt
+from merlin.core import dispatch
 from merlin.core.dispatch import HAS_GPU, make_df
 from merlin.core.utils import set_dask_client
 from merlin.dag import ColumnSelector, postorder_iter_nodes
@@ -156,21 +157,19 @@ def test_gpu_workflow_api(tmpdir, client, df, dataset, gpu_memory_frac, engine, 
 
     dataset_2 = Dataset(glob.glob(str(tmpdir) + "/*.parquet"), part_mem_fraction=gpu_memory_frac)
 
-    df_pp = nvt.dispatch.concat(list(dataset_2.to_iter()), axis=0)
+    df_pp = dispatch.concat(list(dataset_2.to_iter()), axis=0)
 
     if engine == "parquet":
         assert is_integer_dtype(df_pp["name-cat"].dtype)
     assert is_integer_dtype(df_pp["name-string"].dtype)
 
-    num_rows, num_row_groups, col_names = nvt.dispatch.read_parquet_metadata(
-        str(tmpdir) + "/_metadata"
-    )
+    num_rows, num_row_groups, col_names = dispatch.read_parquet_metadata(str(tmpdir) + "/_metadata")
     assert num_rows == len(df_pp)
 
 
 @pytest.mark.parametrize("engine", ["csv", "csv-no-header"])
 def test_gpu_dataset_iterator_csv(df, dataset, engine):
-    df_itr = nvt.dispatch.concat(list(dataset.to_iter(columns=mycols_csv)), axis=0)
+    df_itr = dispatch.concat(list(dataset.to_iter(columns=mycols_csv)), axis=0)
     assert_eq(df_itr.reset_index(drop=True), df.reset_index(drop=True))
 
 
@@ -248,14 +247,12 @@ def test_gpu_workflow(tmpdir, df, dataset, gpu_memory_frac, engine, dump):
 
     dataset_2 = Dataset(glob.glob(str(tmpdir) + "/*.parquet"), part_mem_fraction=gpu_memory_frac)
 
-    df_pp = nvt.dispatch.concat(list(dataset_2.to_iter()), axis=0)
+    df_pp = dispatch.concat(list(dataset_2.to_iter()), axis=0)
 
     if engine == "parquet":
         assert is_integer_dtype(df_pp["name-cat"].dtype)
     assert is_integer_dtype(df_pp["name-string"].dtype)
-    num_rows, num_row_groups, col_names = nvt.dispatch.read_parquet_metadata(
-        str(tmpdir) + "/_metadata"
-    )
+    num_rows, num_row_groups, col_names = dispatch.read_parquet_metadata(str(tmpdir) + "/_metadata")
     assert num_rows == len(df_pp)
 
 
@@ -333,15 +330,13 @@ def test_gpu_workflow_config(tmpdir, client, df, dataset, gpu_memory_frac, engin
 
     dataset_2 = Dataset(glob.glob(str(tmpdir) + "/*.parquet"), part_mem_fraction=gpu_memory_frac)
 
-    df_pp = nvt.dispatch.concat(list(dataset_2.to_iter()), axis=0)
+    df_pp = dispatch.concat(list(dataset_2.to_iter()), axis=0)
 
     if engine == "parquet":
         assert is_integer_dtype(df_pp["name-cat"].dtype)
     assert is_integer_dtype(df_pp["name-string"].dtype)
 
-    num_rows, num_row_groups, col_names = nvt.dispatch.read_parquet_metadata(
-        str(tmpdir) + "/_metadata"
-    )
+    num_rows, num_row_groups, col_names = dispatch.read_parquet_metadata(str(tmpdir) + "/_metadata")
     assert num_rows == len(df_pp)
 
 
@@ -376,7 +371,7 @@ def test_parquet_output(client, use_client, tmpdir, shuffle):
     assert os.path.exists(meta_path)
 
     # Make sure _metadata makes sense
-    _metadata = nvt.dispatch.read_parquet_metadata(meta_path)
+    _metadata = dispatch.read_parquet_metadata(meta_path)
     assert _metadata[0] == size
     assert _metadata[2] == columns
 
@@ -483,7 +478,7 @@ def test_workflow_apply(client, use_client, tmpdir, shuffle, apply_offline):
 
     # Check dtypes
     for filename in glob.glob(os.path.join(out_path, "*.parquet")):
-        gdf = nvt.dispatch.read_dispatch(filename)(filename)
+        gdf = dispatch.read_dispatch(filename)(filename)
         assert dict(gdf.dtypes) == dict_dtypes
 
 

--- a/tests/unit/workflow/test_workflow_node.py
+++ b/tests/unit/workflow/test_workflow_node.py
@@ -1,9 +1,10 @@
 import numpy as np
 import pytest
 
+from merlin.core import dispatch
 from merlin.dag import ColumnSelector
 from merlin.schema import Schema
-from nvtabular import Dataset, Workflow, WorkflowNode, dispatch
+from nvtabular import Dataset, Workflow, WorkflowNode
 from nvtabular.ops import (
     Categorify,
     DifferenceLag,


### PR DESCRIPTION
Functionality like dispatch,io,utils,graph has moved to the merlin-core package.
This change fixes imports to use the merlin-core packages directly, instead of
the API compatability stubs included here

