### PR TITLE
Add `merlin.transforms.ops` sub-package

### DIFF
--- a/merlin/transforms/ops/__init__.py
+++ b/merlin/transforms/ops/__init__.py
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2022, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# pylint: disable=wildcard-import
+
+from nvtabular.ops import *  # noqa


### PR DESCRIPTION
This is just a re-export of `nvtabular.ops` under the `merlin` namespace. Everything else that we intend to be imported from NVT (and that we're not deprecating) is already exported at the top-level.