### PR TITLE
fix for 1455

### DIFF
--- a/examples/tabular-data-rossmann/03-Training-with-TF.ipynb
+++ b/examples/tabular-data-rossmann/03-Training-with-TF.ipynb
@@ -345,7 +345,7 @@
     "# Just concatenating continuous, so can use a list\n",
     "continuous_inputs = []\n",
     "for column_name in CONTINUOUS_COLUMNS:\n",
-    "    continuous_inputs.append(tf.keras.Input(name=column_name, shape=(1,), dtype=tf.float32))\n",
+    "    continuous_inputs.append(tf.keras.Input(name=column_name, shape=(1,), dtype=tf.float64))\n",
     "continuous_embedding_layer = tf.keras.layers.Concatenate(axis=1)\n",
     "continuous_x = continuous_embedding_layer(continuous_inputs)\n",
     "continuous_x = tf.keras.layers.BatchNormalization(epsilon=1e-5, momentum=0.1)(continuous_x)\n",
@@ -542,7 +542,7 @@
  "metadata": {
   "file_extension": ".py",
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -556,7 +556,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.8.10"
   },
   "mimetype": "text/x-python",
   "name": "python",


### PR DESCRIPTION
 this fixes #1455  correctly. The error is happening because we have a collision with how the old export ensemble function work and how new ensembles are created. In old ensembles you can set whatever dtype you want for the models, with new setup dtypes must be respected (i.e. inputs to models should correspond to outputs of the workflow). 