### PR TITLE
Fix for max-size categorify operator category ordering

### DIFF
--- a/nvtabular/ops/categorify.py
+++ b/nvtabular/ops/categorify.py
@@ -1072,7 +1072,7 @@ def _write_uniques(dfs, base_path, col_selector: ColumnSelector, options: FitOpt
                 if nlargest <= 0:
                     raise ValueError("`nlargest` cannot be 0 or negative")
 
-                if nlargest < len(df):
+                if nlargest < len(df) and name_size in df:
                     # remove NAs from column, we have na count from above.
                     df = df.dropna()
                     # sort based on count (name_size column)

--- a/nvtabular/ops/categorify.py
+++ b/nvtabular/ops/categorify.py
@@ -1073,7 +1073,20 @@ def _write_uniques(dfs, base_path, col_selector: ColumnSelector, options: FitOpt
                     raise ValueError("`nlargest` cannot be 0 or negative")
 
                 if nlargest < len(df):
+                    # remove NAs from column, we have na count from above.
+                    df = df.dropna()
+                    # sort based on count (name_size column)
                     df = df.nlargest(n=nlargest, columns=name_size)
+                    new_cols[col] = _concat(
+                        [nullable_series([None], df, df[col].dtype), df[col]],
+                        ignore_index=True,
+                    )
+                    new_cols[name_size] = _concat(
+                        [nullable_series([null_size], df, df[name_size].dtype), df[name_size]],
+                        ignore_index=True,
+                    )
+                    # recreate newly "count" ordered df
+                    df = type(df)(new_cols)
             if not dispatch.series_has_nulls(df[col]):
                 if name_size in df:
                     df = df.sort_values(name_size, ascending=False, ignore_index=True)

--- a/tests/unit/ops/test_categorify.py
+++ b/tests/unit/ops/test_categorify.py
@@ -647,10 +647,10 @@ def test_categorify_max_size_null_iloc_check():
     workflow.transform(train_dataset)
     # read back the unique categories
     unique_C1 = pd.read_parquet("./categories/unique.C1.parquet")
-    assert str(unique_C1["C1"].iloc[0]) == "<NA>"
+    assert str(unique_C1["C1"].iloc[0]) == ("<NA>" or "nan")
     assert unique_C1["C1_size"].iloc[0] == 5
 
     # read back the unique categories
     unique_C2 = pd.read_parquet("./categories/unique.C2.parquet")
-    assert str(unique_C2["C2"].iloc[0]) == "<NA>"
+    assert str(unique_C2["C2"].iloc[0]) == ("<NA>" or "nan")
     assert unique_C2["C2_size"].iloc[0] == 0

--- a/tests/unit/ops/test_categorify.py
+++ b/tests/unit/ops/test_categorify.py
@@ -647,10 +647,10 @@ def test_categorify_max_size_null_iloc_check():
     workflow.transform(train_dataset)
     # read back the unique categories
     unique_C1 = pd.read_parquet("./categories/unique.C1.parquet")
-    assert str(unique_C1["C1"].iloc[0]) == ("<NA>" or "nan")
+    assert str(unique_C1["C1"].iloc[0]) in ["<NA>", "nan"]
     assert unique_C1["C1_size"].iloc[0] == 5
 
     # read back the unique categories
     unique_C2 = pd.read_parquet("./categories/unique.C2.parquet")
-    assert str(unique_C2["C2"].iloc[0]) == ("<NA>" or "nan")
+    assert str(unique_C2["C2"].iloc[0]) in ["<NA>", "nan"]
     assert unique_C2["C2_size"].iloc[0] == 0

--- a/tests/unit/ops/test_categorify.py
+++ b/tests/unit/ops/test_categorify.py
@@ -633,3 +633,24 @@ def test_categorify_domain_max(cpu):
     assert df_transform.schema["Post"].properties["domain"]["max"] > 0
     assert df_transform.schema["Author"].properties["domain"]["max"] > 0
     assert df_transform.schema["Engaging User"].properties["domain"]["max"] > 0
+
+
+def test_categorify_max_size_null_iloc_check():
+    gdf = make_df({"C1": [1, np.nan, 3, 4, 3] * 5, "C2": [1, 1, 2, 3, 6] * 5})
+
+    cat_features = ["C1", "C2"] >> nvt.ops.Categorify(max_size=4)
+
+    train_dataset = nvt.Dataset(gdf)
+
+    workflow = nvt.Workflow(cat_features)
+    workflow.fit(train_dataset)
+    workflow.transform(train_dataset)
+    # read back the unique categories
+    unique_C1 = pd.read_parquet("./categories/unique.C1.parquet")
+    assert str(unique_C1["C1"].iloc[0]) == "<NA>"
+    assert unique_C1["C1_size"].iloc[0] == 5
+
+    # read back the unique categories
+    unique_C2 = pd.read_parquet("./categories/unique.C2.parquet")
+    assert str(unique_C2["C2"].iloc[0]) == "<NA>"
+    assert unique_C2["C2_size"].iloc[0] == 0


### PR DESCRIPTION
This PR fixes a bug in the categorify op when using the max_size kwarg #1517 . When doing so the ordering of categories is shifted unexpected because ordering is based on count and done after adding the null entry.  