### PR TITLE
Remove message about integration tests missing

### DIFF
--- a/ci/test_integration.sh
+++ b/ci/test_integration.sh
@@ -54,6 +54,4 @@ elif [ "$container" == "merlin-tensorflow-inference" ]; then
 elif [ "$container" == "merlin-inference" ]; then
   pytest $config tests/integration/test_notebooks.py::test_criteo
   pytest $config tests/integration/test_nvt_hugectr.py::test_inference
-else
-  echo "No tests to run for this container"
 fi


### PR DESCRIPTION
There was an erroneous message being displayed say "no tests to run"
during integration tests, when there was in fact tests being run.
Remove the message.
