### PR TITLE
Add release-drafter workflow for generating changelogs

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -9,11 +9,16 @@ categories:
   labels:
   - 'feature'
   - 'enhancement'
+- title: '📄 Documentation'
+  labels:
+  - 'documentation'
+  - 'examples'
 - title: '🔧 Maintenance'
   labels:
-  - build
-  - dependencies
-  - chore
+  - 'build'
+  - 'dependencies'
+  - 'chore'
+  - 'ci'
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 exclude-labels:
   - 'skip-changelog'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,22 @@
+categories:
+- title: '⚠ Breaking Changes'
+  labels:
+  - 'breaking'
+- title: '🐜 Bug Fixes'
+  labels:
+  - 'bug'
+- title: '🚀 Features'
+  labels:
+  - 'feature'
+  - 'enhancement'
+- title: '🔧 Maintenance'
+  labels:
+  - build
+  - dependencies
+  - chore
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+exclude-labels:
+  - 'skip-changelog'
+template: |
+  ## What’s Changed
+  $CHANGES

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -24,4 +24,5 @@ exclude-labels:
   - 'skip-changelog'
 template: |
   ## What’s Changed
+
   $CHANGES

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,23 @@
+name: Release Drafter
+
+on:
+  push:
+    # branches to consider in the event; optional, defaults to all
+    branches:
+      - main
+  # pull_request event is required only for autolabeler
+  pull_request:
+    # Only following types are handled by the action, but one can default to all as well
+    types: [opened, reopened, synchronize]
+  # pull_request_target event is required for autolabeler to support PRs from forks
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "main"
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Automatically generate changelogs using release-drafter
https://github.com/release-drafter/release-drafter . This will
categorize PR's into different sections of the changelog based
on labels (breaking/bug/feature etc).

