### PR TITLE
Use common release-drafter workflow

### DIFF
--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -1,23 +1,19 @@
-name: Release Drafter
+name: release-drafter
 
 on:
   push:
     # branches to consider in the event; optional, defaults to all
     branches:
-      - main
+      - "main"
   # pull_request event is required only for autolabeler
   pull_request:
     # Only following types are handled by the action, but one can default to all as well
     types: [opened, reopened, synchronize]
   # pull_request_target event is required for autolabeler to support PRs from forks
-  pull_request_target:
-    types: [opened, reopened, synchronize]
+  # pull_request_target:
+  #  types: [opened, reopened, synchronize]
+  workflow_dispatch:
 
 jobs:
   update_release_draft:
-    runs-on: ubuntu-latest
-    steps:
-      # Drafts your next Release notes as Pull Requests are merged into "main"
-      - uses: release-drafter/release-drafter@v5
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    uses: nvidia-merlin/.github/.github/workflows/release-drafter-common.yaml@main


### PR DESCRIPTION
Add the reusable release-drafter workflow from the
organization repository.
