### PR TITLE
Update changelog to point to github releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+# Release notes are now being hosted in GitHub Releases https://github.com/NVIDIA-Merlin/NVTabular/releases
 
 # NVTabular v0.7.1 (2 November 2021)
 


### PR DESCRIPTION
We haven't updated the changelog since November 2021, and have
been relying on GitHub releases instead. Point the changelog to GH
releases instead
