### PR TITLE
revamp how we use the proto file

### DIFF
--- a/nvtabular/inference/triton/ensemble.py
+++ b/nvtabular/inference/triton/ensemble.py
@@ -27,7 +27,7 @@ os.environ["PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION"] = "python"
 
 from google.protobuf import text_format  # noqa
 
-import nvtabular.inference.triton.model_config_pb2 as model_config  # noqa
+import nvtabular.inference.triton.model_config_util as model_config  # noqa
 from merlin.core.dispatch import is_string_dtype  # noqa
 from merlin.schema import Tags  # noqa
 

--- a/nvtabular/inference/triton/model_config_util.py
+++ b/nvtabular/inference/triton/model_config_util.py
@@ -4,24 +4,23 @@ from google.protobuf.message_factory import MessageFactory
 def_pool = Default()
 msg_factory = MessageFactory(pool=def_pool)
 file_descriptor = def_pool.FindFileByName("model_config.proto")
-if file_descriptor:
-    ModelConfig = msg_factory.CreatePrototype(file_descriptor.message_types_by_name["ModelConfig"])
-    ModelInput = msg_factory.CreatePrototype(file_descriptor.message_types_by_name["ModelInput"])
-    ModelOutput = msg_factory.CreatePrototype(file_descriptor.message_types_by_name["ModelOutput"])
-    ModelEnsembling = msg_factory.CreatePrototype(
-        file_descriptor.message_types_by_name["ModelEnsembling"]
-    )
-    _DATATYPE = file_descriptor.enum_types_by_name["DataType"]
-    TYPE_FP64 = _DATATYPE.values_by_name["TYPE_FP64"].number
-    TYPE_FP32 = _DATATYPE.values_by_name["TYPE_FP32"].number
-    TYPE_FP16 = _DATATYPE.values_by_name["TYPE_FP16"].number
-    TYPE_INT64 = _DATATYPE.values_by_name["TYPE_INT64"].number
-    TYPE_INT32 = _DATATYPE.values_by_name["TYPE_INT32"].number
-    TYPE_INT16 = _DATATYPE.values_by_name["TYPE_INT16"].number
-    TYPE_INT8 = _DATATYPE.values_by_name["TYPE_INT8"].number
-    TYPE_UINT64 = _DATATYPE.values_by_name["TYPE_UINT64"].number
-    TYPE_UINT32 = _DATATYPE.values_by_name["TYPE_UINT32"].number
-    TYPE_UINT16 = _DATATYPE.values_by_name["TYPE_UINT16"].number
-    TYPE_UINT8 = _DATATYPE.values_by_name["TYPE_UINT8"].number
-    TYPE_BOOL = _DATATYPE.values_by_name["TYPE_BOOL"].number
-    TYPE_STRING = _DATATYPE.values_by_name["TYPE_STRING"].number
+ModelConfig = msg_factory.CreatePrototype(file_descriptor.message_types_by_name["ModelConfig"])
+ModelInput = msg_factory.CreatePrototype(file_descriptor.message_types_by_name["ModelInput"])
+ModelOutput = msg_factory.CreatePrototype(file_descriptor.message_types_by_name["ModelOutput"])
+ModelEnsembling = msg_factory.CreatePrototype(
+    file_descriptor.message_types_by_name["ModelEnsembling"]
+)
+_DATATYPE = file_descriptor.enum_types_by_name["DataType"]
+TYPE_FP64 = _DATATYPE.values_by_name["TYPE_FP64"].number
+TYPE_FP32 = _DATATYPE.values_by_name["TYPE_FP32"].number
+TYPE_FP16 = _DATATYPE.values_by_name["TYPE_FP16"].number
+TYPE_INT64 = _DATATYPE.values_by_name["TYPE_INT64"].number
+TYPE_INT32 = _DATATYPE.values_by_name["TYPE_INT32"].number
+TYPE_INT16 = _DATATYPE.values_by_name["TYPE_INT16"].number
+TYPE_INT8 = _DATATYPE.values_by_name["TYPE_INT8"].number
+TYPE_UINT64 = _DATATYPE.values_by_name["TYPE_UINT64"].number
+TYPE_UINT32 = _DATATYPE.values_by_name["TYPE_UINT32"].number
+TYPE_UINT16 = _DATATYPE.values_by_name["TYPE_UINT16"].number
+TYPE_UINT8 = _DATATYPE.values_by_name["TYPE_UINT8"].number
+TYPE_BOOL = _DATATYPE.values_by_name["TYPE_BOOL"].number
+TYPE_STRING = _DATATYPE.values_by_name["TYPE_STRING"].number

--- a/nvtabular/inference/triton/model_config_util.py
+++ b/nvtabular/inference/triton/model_config_util.py
@@ -8,17 +8,20 @@ if file_descriptor:
     ModelConfig = msg_factory.CreatePrototype(file_descriptor.message_types_by_name["ModelConfig"])
     ModelInput = msg_factory.CreatePrototype(file_descriptor.message_types_by_name["ModelInput"])
     ModelOutput = msg_factory.CreatePrototype(file_descriptor.message_types_by_name["ModelOutput"])
-    enum_descriptor = file_descriptor.enum_types_by_name["DataType"]
-    TYPE_FP64 = enum_descriptor.values_by_name["TYPE_FP64"].number
-    TYPE_FP32 = enum_descriptor.values_by_name["TYPE_FP32"].number
-    TYPE_FP16 = enum_descriptor.values_by_name["TYPE_FP16"].number
-    TYPE_INT64 = enum_descriptor.values_by_name["TYPE_INT64"].number
-    TYPE_INT32 = enum_descriptor.values_by_name["TYPE_INT32"].number
-    TYPE_INT16 = enum_descriptor.values_by_name["TYPE_INT16"].number
-    TYPE_INT8 = enum_descriptor.values_by_name["TYPE_INT8"].number
-    TYPE_UINT64 = enum_descriptor.values_by_name["TYPE_UINT64"].number
-    TYPE_UINT32 = enum_descriptor.values_by_name["TYPE_UINT32"].number
-    TYPE_UINT16 = enum_descriptor.values_by_name["TYPE_UINT16"].number
-    TYPE_UINT8 = enum_descriptor.values_by_name["TYPE_UINT8"].number
-    TYPE_BOOL = enum_descriptor.values_by_name["TYPE_BOOL"].number
-    TYPE_STRING = enum_descriptor.values_by_name["TYPE_STRING"].number
+    ModelEnsembling = msg_factory.CreatePrototype(
+        file_descriptor.message_types_by_name["ModelEnsembling"]
+    )
+    _DATATYPE = file_descriptor.enum_types_by_name["DataType"]
+    TYPE_FP64 = _DATATYPE.values_by_name["TYPE_FP64"].number
+    TYPE_FP32 = _DATATYPE.values_by_name["TYPE_FP32"].number
+    TYPE_FP16 = _DATATYPE.values_by_name["TYPE_FP16"].number
+    TYPE_INT64 = _DATATYPE.values_by_name["TYPE_INT64"].number
+    TYPE_INT32 = _DATATYPE.values_by_name["TYPE_INT32"].number
+    TYPE_INT16 = _DATATYPE.values_by_name["TYPE_INT16"].number
+    TYPE_INT8 = _DATATYPE.values_by_name["TYPE_INT8"].number
+    TYPE_UINT64 = _DATATYPE.values_by_name["TYPE_UINT64"].number
+    TYPE_UINT32 = _DATATYPE.values_by_name["TYPE_UINT32"].number
+    TYPE_UINT16 = _DATATYPE.values_by_name["TYPE_UINT16"].number
+    TYPE_UINT8 = _DATATYPE.values_by_name["TYPE_UINT8"].number
+    TYPE_BOOL = _DATATYPE.values_by_name["TYPE_BOOL"].number
+    TYPE_STRING = _DATATYPE.values_by_name["TYPE_STRING"].number

--- a/nvtabular/inference/triton/model_config_util.py
+++ b/nvtabular/inference/triton/model_config_util.py
@@ -8,21 +8,17 @@ if file_descriptor:
     ModelConfig = msg_factory.CreatePrototype(file_descriptor.message_types_by_name["ModelConfig"])
     ModelInput = msg_factory.CreatePrototype(file_descriptor.message_types_by_name["ModelInput"])
     ModelOutput = msg_factory.CreatePrototype(file_descriptor.message_types_by_name["ModelOutput"])
-    TYPE_FP64 = file_descriptor.enum_types_by_name["DataType"].values_by_name["TYPE_FP64"].number
-    TYPE_FP32 = file_descriptor.enum_types_by_name["DataType"].values_by_name["TYPE_FP32"].number
-    TYPE_FP16 = file_descriptor.enum_types_by_name["DataType"].values_by_name["TYPE_FP16"].number
-    TYPE_INT64 = file_descriptor.enum_types_by_name["DataType"].values_by_name["TYPE_INT64"].number
-    TYPE_INT32 = file_descriptor.enum_types_by_name["DataType"].values_by_name["TYPE_INT32"].number
-    TYPE_INT16 = file_descriptor.enum_types_by_name["DataType"].values_by_name["TYPE_INT16"].number
-    TYPE_INT8 = file_descriptor.enum_types_by_name["DataType"].values_by_name["TYPE_INT8"].number
-    TYPE_UINT64 = (
-        file_descriptor.enum_types_by_name["DataType"].values_by_name["TYPE_UINT64"].number
-    )
-    TYPE_UINT32 = (
-        file_descriptor.enum_types_by_name["DataType"].values_by_name["TYPE_UINT32"].number
-    )
-    TYPE_UINT16 = (
-        file_descriptor.enum_types_by_name["DataType"].values_by_name["TYPE_UINT16"].number
-    )
-    TYPE_UINT8 = file_descriptor.enum_types_by_name["DataType"].values_by_name["TYPE_UINT8"].number
-    TYPE_BOOL = file_descriptor.enum_types_by_name["DataType"].values_by_name["TYPE_BOOL"].number
+    enum_descriptor = file_descriptor.enum_types_by_name["DataType"]
+    TYPE_FP64 = enum_descriptor.values_by_name["TYPE_FP64"].number
+    TYPE_FP32 = enum_descriptor.values_by_name["TYPE_FP32"].number
+    TYPE_FP16 = enum_descriptor.values_by_name["TYPE_FP16"].number
+    TYPE_INT64 = enum_descriptor.values_by_name["TYPE_INT64"].number
+    TYPE_INT32 = enum_descriptor.values_by_name["TYPE_INT32"].number
+    TYPE_INT16 = enum_descriptor.values_by_name["TYPE_INT16"].number
+    TYPE_INT8 = enum_descriptor.values_by_name["TYPE_INT8"].number
+    TYPE_UINT64 = enum_descriptor.values_by_name["TYPE_UINT64"].number
+    TYPE_UINT32 = enum_descriptor.values_by_name["TYPE_UINT32"].number
+    TYPE_UINT16 = enum_descriptor.values_by_name["TYPE_UINT16"].number
+    TYPE_UINT8 = enum_descriptor.values_by_name["TYPE_UINT8"].number
+    TYPE_BOOL = enum_descriptor.values_by_name["TYPE_BOOL"].number
+    TYPE_STRING = enum_descriptor.values_by_name["TYPE_STRING"].number

--- a/nvtabular/inference/triton/model_config_util.py
+++ b/nvtabular/inference/triton/model_config_util.py
@@ -1,0 +1,28 @@
+from google.protobuf.descriptor_pool import Default
+from google.protobuf.message_factory import MessageFactory
+
+def_pool = Default()
+msg_factory = MessageFactory(pool=def_pool)
+file_descriptor = def_pool.FindFileByName("model_config.proto")
+if file_descriptor:
+    ModelConfig = msg_factory.CreatePrototype(file_descriptor.message_types_by_name["ModelConfig"])
+    ModelInput = msg_factory.CreatePrototype(file_descriptor.message_types_by_name["ModelInput"])
+    ModelOutput = msg_factory.CreatePrototype(file_descriptor.message_types_by_name["ModelOutput"])
+    TYPE_FP64 = file_descriptor.enum_types_by_name["DataType"].values_by_name["TYPE_FP64"].number
+    TYPE_FP32 = file_descriptor.enum_types_by_name["DataType"].values_by_name["TYPE_FP32"].number
+    TYPE_FP16 = file_descriptor.enum_types_by_name["DataType"].values_by_name["TYPE_FP16"].number
+    TYPE_INT64 = file_descriptor.enum_types_by_name["DataType"].values_by_name["TYPE_INT64"].number
+    TYPE_INT32 = file_descriptor.enum_types_by_name["DataType"].values_by_name["TYPE_INT32"].number
+    TYPE_INT16 = file_descriptor.enum_types_by_name["DataType"].values_by_name["TYPE_INT16"].number
+    TYPE_INT8 = file_descriptor.enum_types_by_name["DataType"].values_by_name["TYPE_INT8"].number
+    TYPE_UINT64 = (
+        file_descriptor.enum_types_by_name["DataType"].values_by_name["TYPE_UINT64"].number
+    )
+    TYPE_UINT32 = (
+        file_descriptor.enum_types_by_name["DataType"].values_by_name["TYPE_UINT32"].number
+    )
+    TYPE_UINT16 = (
+        file_descriptor.enum_types_by_name["DataType"].values_by_name["TYPE_UINT16"].number
+    )
+    TYPE_UINT8 = file_descriptor.enum_types_by_name["DataType"].values_by_name["TYPE_UINT8"].number
+    TYPE_BOOL = file_descriptor.enum_types_by_name["DataType"].values_by_name["TYPE_BOOL"].number


### PR DESCRIPTION
This PR introduces a new file which is charged with interacting with protobuf on the system and gathering the required messages and enums from the previously created protobuf file. This will decouple the proto compilation, from the usage.  Which alleviates the file cannot be created because already exists in the pool.