### PR TITLE
Update the container labels in the integration tests

### DIFF
--- a/ci/test_integration.sh
+++ b/ci/test_integration.sh
@@ -19,8 +19,7 @@ set -e
 
 # Call this script with:
 # 1. Name of container as first parameter
-#    [merlin-training,  merlin-tensorflow-training,  merlin-pytorch-training, 
-#     merlin-inference, merlin-tensorflow-inference, merlin-pytorch-inference]
+#    [merlin-hugectr,  merlin-tensorflow,  merlin-pytorch]
 #
 # 2. Devices to use:
 #    [0; 0,1; 0,1,..,n-1]
@@ -33,25 +32,20 @@ container=$1
 config="-rsx --devices $2"
 
 # Run tests for training containers
-regex="merlin(.)*-inference"
-if [[ ! "$container" =~ $regex ]]; then
-  #pytest $config tests/integration/test_notebooks.py::test_criteo
-  pytest $config tests/integration/test_notebooks.py::test_rossman
-  pytest $config tests/integration/test_notebooks.py::test_movielens
-fi
+#pytest $config tests/integration/test_notebooks.py::test_criteo
+pytest $config tests/integration/test_notebooks.py::test_rossman
+pytest $config tests/integration/test_notebooks.py::test_movielens
 
 # Run tests for specific containers
-if [ "$container" == "merlin-training" ]; then
+if [ "$container" == "merlin-hugectr" ]; then
   pytest $config tests/integration/test_nvt_hugectr.py::test_training
-elif [ "$container" == "merlin-tensorflow-training" ]; then
+  pytest $config tests/integration/test_notebooks.py::test_criteo
+  pytest $config tests/integration/test_nvt_hugectr.py::test_inference
+elif [ "$container" == "merlin-tensorflow" ]; then
   pytest $config tests/integration/test_nvt_tf_inference.py::test_nvt_tf_rossmann_inference
   pytest $config tests/integration/test_nvt_tf_inference.py::test_nvt_tf_movielens_inference
-elif [ "$container" == "merlin-tensorflow-inference" ]; then
   pytest $config tests/integration/test_nvt_tf_inference.py::test_nvt_tf_rossmann_inference_triton
   pytest $config tests/integration/test_nvt_tf_inference.py::test_nvt_tf_rossmann_inference_triton_mt
   pytest $config tests/integration/test_nvt_tf_inference.py::test_nvt_tf_movielens_inference_triton
   pytest $config tests/integration/test_nvt_tf_inference.py::test_nvt_tf_movielens_inference_triton_mt
-elif [ "$container" == "merlin-inference" ]; then
-  pytest $config tests/integration/test_notebooks.py::test_criteo
-  pytest $config tests/integration/test_nvt_hugectr.py::test_inference
 fi

--- a/tests/integration/test_notebooks.py
+++ b/tests/integration/test_notebooks.py
@@ -41,10 +41,9 @@ ROSSMAN_DIR = "examples/tabular-data-rossmann"
 MOVIELENS_DIR = "examples/getting-started-movielens"
 
 allowed_hosts = [
-    "merlin-training",
-    "merlin-tensorflow-training",
-    "merlin-torch-training",
-    "merlin-inference",
+    "merlin-hugectr",
+    "merlin-tensorflow",
+    "merlin-pytorch",
 ]
 
 


### PR DESCRIPTION
We've recently changed the labels for the containers, as part of unifying the
training and inference containers. This meant that certain container verification
scripts were not getting run appropriately

