### PR TITLE
column names can now include aggregations in ops.Groupby

### DIFF
--- a/nvtabular/ops/groupby.py
+++ b/nvtabular/ops/groupby.py
@@ -244,9 +244,9 @@ def _apply_aggs(_df, groupby_cols, _list_aggs, _conv_aggs, name_sep="_", ascendi
             df.drop(columns=[col + f"{name_sep}list"], inplace=True)
 
     for col in df.columns:
-        if re.search(f"{name_sep}(count|nunique)", col):
+        if re.search(f"{name_sep}(count|nunique)$", col):
             df[col] = df[col].astype(numpy.int32)
-        elif re.search(f"{name_sep}(mean|median|std|var)", col):
+        elif re.search(f"{name_sep}(mean|median|std|var)$", col):
             df[col] = df[col].astype(numpy.float32)
 
     return df

--- a/tests/unit/ops/test_groupyby.py
+++ b/tests/unit/ops/test_groupyby.py
@@ -211,6 +211,8 @@ def test_groupby_column_names_containing_aggregations(cpu):
     # Initial dataset
     size = 60
     names = ["Dave", "Zelda"]
+    # The column to be aggregated contains name of an aggregation -- count.
+    # This could lead to it being cast to incorrect dtype.
     df1 = make_df(
         {
             "name": np.random.choice(names, size=size),

--- a/tests/unit/ops/test_groupyby.py
+++ b/tests/unit/ops/test_groupyby.py
@@ -204,3 +204,30 @@ def test_groupby_casting_in_aggregations(cpu):
                 with_agg = new_gdf.loc[new_gdf.name == name, f"{col}-{agg}"]
                 with_agg = with_agg.item() if hasattr(with_agg, "item") else with_agg.loc[0][0]
                 assert np.allclose(without_agg, with_agg)
+
+
+@pytest.mark.parametrize("cpu", _CPU)
+def test_groupby_column_names_containing_aggregations(cpu):
+    # Initial dataset
+    size = 60
+    names = ["Dave", "Zelda"]
+    df1 = make_df(
+        {
+            "name": np.random.choice(names, size=size),
+            "test_score_counting_to_10": np.random.uniform(low=0.0, high=10.0, size=size),
+        }
+    )
+
+    # Create a ddf, and be sure to shuffle by the groupby keys
+    ddf1 = dd.from_pandas(df1, npartitions=3).shuffle("name")
+    dataset = nvt.Dataset(ddf1, cpu=cpu)
+
+    # Define Groupby Workflow
+    groupby_features = ["name", "test_score_counting_to_10"] >> ops.Groupby(
+        groupby_cols="name", aggs={"test_score_counting_to_10": "mean"}
+    )
+    processor = nvt.Workflow(groupby_features)
+    processor.fit(dataset)
+    new_gdf = processor.transform(dataset).to_ddf().compute()
+
+    assert new_gdf is not None


### PR DESCRIPTION
I found a bug where if a column contained the name of one of the aggregations in `Groupby`, and a `Groupby` op was applied to it, the `dtype` could be cast incorrectly.

The behavior is outlined in the unit test and the proposed code changes fix this.