### PR TITLE
fix notebook input output paths for int testing on read only data

### DIFF
--- a/tests/integration/test_notebooks.py
+++ b/tests/integration/test_notebooks.py
@@ -120,8 +120,8 @@ def test_criteo(asv_db, bench_info, tmpdir, report):
 
 def test_rossman(asv_db, bench_info, tmpdir, devices, report):
     data_path = os.path.join(DATA_DIR, "rossman/data")
-    input_path = os.path.join(DATA_DIR, "rossman/input")
-    output_path = os.path.join(DATA_DIR, "rossman/output")
+    input_path = "rossman/input"
+    output_path = "rossman/output"
 
     # Run Download & Convert for all
     notebook = os.path.join(dirname(TEST_PATH), ROSSMAN_DIR, "01-Download-Convert.ipynb")


### PR DESCRIPTION
This fixes the rossman test. Currently reading and writing data to the same place. This is not acceptable on blossom where the data is stored in a read only drive.