### PR TITLE
Groupby to no longer require groupby_cols in column selector

### DIFF
--- a/nvtabular/ops/groupby.py
+++ b/nvtabular/ops/groupby.py
@@ -180,6 +180,10 @@ class Groupby(Operator):
 
         return column_mapping
 
+    @property
+    def dependencies(self):
+        return self.groupby_cols
+
     def _compute_dtype(self, col_schema, input_schema):
         col_schema = super()._compute_dtype(col_schema, input_schema)
 

--- a/tests/unit/ops/test_groupyby.py
+++ b/tests/unit/ops/test_groupyby.py
@@ -164,6 +164,7 @@ def test_groupby_selector_cols():
     # If groupby_cols aren't included in the selector, they shouldn't be in the output
     assert "name" not in workflow.output_node.output_schema.column_names
 
+
 @pytest.mark.parametrize("cpu", _CPU)
 def test_groupby_without_selector_in_groupby_cols(cpu):
     # Initial sales dataset
@@ -178,13 +179,12 @@ def test_groupby_without_selector_in_groupby_cols(cpu):
     ddf1 = dd.from_pandas(df1, npartitions=3).shuffle(["day"])
     dataset = nvt.Dataset(ddf1, cpu=cpu)
 
-    groupby_features = ["product_id"] >> ops.Groupby(
-        groupby_cols=["day"], aggs="count"
-    )
+    groupby_features = ["product_id"] >> ops.Groupby(groupby_cols=["day"], aggs="count")
 
     processor = nvt.Workflow(groupby_features)
     processor.fit(dataset)
-    processor.transform(dataset).to_ddf().compute()
+    assert processor.transform(dataset).to_ddf().compute().columns.tolist() == ["product_id_count"]
+
 
 @pytest.mark.parametrize("cpu", _CPU)
 def test_groupby_casting_in_aggregations(cpu):


### PR DESCRIPTION
This is just to demonstrate an issue (I added a test for a case I will describe in a bug report).

I am not sure, but since I pushed to the Merlin/NVTabular repo others can contribute to this branch as well (vs if I pushed to my fork and opened a PR from there)? Not sure. But maybe this can be useful to addressing the issue.
