### PR TITLE
Don't install tests with nvtabular

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ install_reqs = parse_requirements("./requirements.txt")
 setup(
     name="nvtabular",
     version=versioneer.get_version(),
-    packages=find_packages() + find_namespace_packages(),
+    packages=find_packages(include=["nvtabular*"]) + find_namespace_packages(include=["merlin*"]),
     url="https://github.com/NVIDIA-Merlin/NVTabular",
     author="NVIDIA Corporation",
     license="Apache 2.0",


### PR DESCRIPTION
Currently the tests folder is getting installed, and after installing nvtabular
going 'import tests' will grab the installed nvtabular tests.

This caused some CI failures in other projects https://github.com/NVIDIA-Merlin/dataloader/runs/7292718750?check_suite_focus=true

Fix by limiting to only install nvtabular/merlin packages.

