### PR TITLE
Integration tests refactor

### DIFF
--- a/examples/scaling-criteo/04-Triton-Inference-with-HugeCTR.ipynb
+++ b/examples/scaling-criteo/04-Triton-Inference-with-HugeCTR.ipynb
@@ -122,7 +122,7 @@
     "import nvtabular as nvt\n",
     "\n",
     "BASE_DIR = os.environ.get(\"BASE_DIR\", \"/raid/data/criteo\")\n",
-    "input_path = os.path.join(BASE_DIR, \"test_dask/output\")\n",
+    "input_path = os.environ.get(\"INPUT_DATA_DIR\", os.path.join(BASE_DIR, \"test_dask/output\"))\n",
     "workflow = nvt.Workflow.load(os.path.join(input_path, \"workflow\"))"
    ]
   },
@@ -150,7 +150,7 @@
     }
    ],
    "source": [
-    "os.system(\"rm -rf /model/*\")"
+    "os.system(f\"rm -rf /tmp/model/*\")"
    ]
   },
   {
@@ -162,7 +162,7 @@
     "from nvtabular.inference.triton import export_hugectr_ensemble\n",
     "\n",
     "hugectr_params = dict()\n",
-    "hugectr_params[\"config\"] = \"/model/criteo/1/criteo.json\"\n",
+    "hugectr_params[\"config\"] = \"/tmp/model/criteo/1/criteo.json\"\n",
     "hugectr_params[\"slots\"] = 26\n",
     "hugectr_params[\"max_nnz\"] = 1\n",
     "hugectr_params[\"embedding_vector_size\"] = 128\n",
@@ -172,7 +172,7 @@
     "    hugectr_model_path=\"./criteo_hugectr/1/\",\n",
     "    hugectr_params=hugectr_params,\n",
     "    name=\"criteo\",\n",
-    "    output_path=\"/model/\",\n",
+    "    output_path=\"/tmp/model/\",\n",
     "    label_columns=[\"label\"],\n",
     "    cats=[\"C\" + str(x) for x in range(1, 27)],\n",
     "    conts=[\"I\" + str(x) for x in range(1, 14)],\n",
@@ -252,7 +252,7 @@
     }
    ],
    "source": [
-    "!tree /model"
+    "!tree /tmp/model"
    ]
   },
   {
@@ -280,16 +280,16 @@
     }
    ],
    "source": [
-    "%%writefile '/model/ps.json'\n",
+    "%%writefile f'/tmp/model/ps.json'\n",
     "\n",
     "{\n",
     "    \"supportlonglong\": true,\n",
     "    \"models\": [\n",
     "        {\n",
     "            \"model\": \"criteo\",\n",
-    "            \"sparse_files\": [\"/model/criteo/1/0_sparse_9600.model\"],\n",
-    "            \"dense_file\": \"/model/criteo/1/_dense_9600.model\",\n",
-    "            \"network_file\": \"/model/criteo/1/criteo.json\",\n",
+    "            \"sparse_files\": [\"/tmp/model/criteo/1/0_sparse_9600.model\"],\n",
+    "            \"dense_file\": \"/tmp/model/criteo/1/_dense_9600.model\",\n",
+    "            \"network_file\": \"/tmp/model/criteo/1/criteo.json\",\n",
     "            \"max_batch_size\": \"64\",\n",
     "            \"gpucache\": \"true\",\n",
     "            \"hit_rate_threshold\": \"0.9\",\n",
@@ -570,6 +570,7 @@
     "df_lib = get_lib()\n",
     "\n",
     "# read in the workflow (to get input/output schema to call triton with)\n",
+    "BASE_DIR = os.environ.get(\"BASE_DIR\", \"/raid/data/criteo\")\n",
     "batch_path = os.path.join(BASE_DIR, \"converted/criteo\")\n",
     "batch = df_lib.read_parquet(os.path.join(batch_path, \"*.parquet\"), num_rows=3)\n",
     "batch = batch[[x for x in batch.columns if x != \"label\"]]\n",
@@ -650,6 +651,7 @@
    "source": [
     "import tritonclient.http as httpclient\n",
     "from tritonclient.utils import np_to_triton_dtype\n",
+    "import numpy as np\n",
     "\n",
     "inputs = []\n",
     "\n",

--- a/examples/scaling-criteo/04-Triton-Inference-with-TF.ipynb
+++ b/examples/scaling-criteo/04-Triton-Inference-with-TF.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -61,7 +61,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -73,17 +73,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "BASE_DIR = os.environ.get(\"BASE_DIR\", \"/raid/data/criteo\")\n",
-    "input_path = os.path.join(BASE_DIR, \"test_dask/output\")"
+    "input_path = os.environ.get(\"INPUT_DATA_DIR\", os.path.join(BASE_DIR, \"test_dask/output\"))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -92,7 +92,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -108,7 +108,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -126,7 +126,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -135,19 +135,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO:tensorflow:Assets written to: /models/criteo_tf/1/model.savedmodel/assets\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "export_tensorflow_ensemble(model, workflow, \"criteo\", \"/models\", [\"label\"])"
+    "export_tensorflow_ensemble(model, workflow, \"criteo\", \"/tmp/model/models/\", [\"label\"])"
    ]
   },
   {
@@ -159,67 +151,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[01;34m/models\u001b[00m\n",
-      "├── \u001b[01;34mcriteo\u001b[00m\n",
-      "│   ├── \u001b[01;34m1\u001b[00m\n",
-      "│   └── config.pbtxt\n",
-      "├── \u001b[01;34mcriteo_nvt\u001b[00m\n",
-      "│   ├── \u001b[01;34m1\u001b[00m\n",
-      "│   │   ├── model.py\n",
-      "│   │   └── \u001b[01;34mworkflow\u001b[00m\n",
-      "│   │       ├── \u001b[01;34mcategories\u001b[00m\n",
-      "│   │       │   ├── unique.C1.parquet\n",
-      "│   │       │   ├── unique.C10.parquet\n",
-      "│   │       │   ├── unique.C11.parquet\n",
-      "│   │       │   ├── unique.C12.parquet\n",
-      "│   │       │   ├── unique.C13.parquet\n",
-      "│   │       │   ├── unique.C14.parquet\n",
-      "│   │       │   ├── unique.C15.parquet\n",
-      "│   │       │   ├── unique.C16.parquet\n",
-      "│   │       │   ├── unique.C17.parquet\n",
-      "│   │       │   ├── unique.C18.parquet\n",
-      "│   │       │   ├── unique.C19.parquet\n",
-      "│   │       │   ├── unique.C2.parquet\n",
-      "│   │       │   ├── unique.C20.parquet\n",
-      "│   │       │   ├── unique.C21.parquet\n",
-      "│   │       │   ├── unique.C22.parquet\n",
-      "│   │       │   ├── unique.C23.parquet\n",
-      "│   │       │   ├── unique.C24.parquet\n",
-      "│   │       │   ├── unique.C25.parquet\n",
-      "│   │       │   ├── unique.C26.parquet\n",
-      "│   │       │   ├── unique.C3.parquet\n",
-      "│   │       │   ├── unique.C4.parquet\n",
-      "│   │       │   ├── unique.C5.parquet\n",
-      "│   │       │   ├── unique.C6.parquet\n",
-      "│   │       │   ├── unique.C7.parquet\n",
-      "│   │       │   ├── unique.C8.parquet\n",
-      "│   │       │   └── unique.C9.parquet\n",
-      "│   │       ├── metadata.json\n",
-      "│   │       └── workflow.pkl\n",
-      "│   └── config.pbtxt\n",
-      "└── \u001b[01;34mcriteo_tf\u001b[00m\n",
-      "    ├── \u001b[01;34m1\u001b[00m\n",
-      "    │   └── \u001b[01;34mmodel.savedmodel\u001b[00m\n",
-      "    │       ├── \u001b[01;34massets\u001b[00m\n",
-      "    │       ├── saved_model.pb\n",
-      "    │       └── \u001b[01;34mvariables\u001b[00m\n",
-      "    │           ├── variables.data-00000-of-00001\n",
-      "    │           └── variables.index\n",
-      "    └── config.pbtxt\n",
-      "\n",
-      "11 directories, 35 files\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "!tree /models"
+    "# !tree /model"
    ]
   },
   {
@@ -240,25 +176,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'status': 'ok', 'restart': True}"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "import IPython\n",
+    "# import IPython\n",
     "\n",
-    "app = IPython.Application.instance()\n",
-    "app.kernel.do_shutdown(True)"
+    "# app = IPython.Application.instance()\n",
+    "# app.kernel.do_shutdown(True)"
    ]
   },
   {
@@ -270,7 +195,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -288,7 +213,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -300,10 +225,10 @@
     }
    ],
    "source": [
-    "import tritonhttpclient\n",
+    "import tritonclient.grpc as grpc_client\n",
     "\n",
     "try:\n",
-    "    triton_client = tritonhttpclient.InferenceServerClient(url=\"triton:8000\", verbose=True)\n",
+    "    triton_client = grpc_client.InferenceServerClient(url=\"localhost:8001\", verbose=True)\n",
     "    print(\"client created.\")\n",
     "except Exception as e:\n",
     "    print(\"channel creation failed: \" + str(e))"
@@ -318,7 +243,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -336,15 +261,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "GET /v2/health/live, headers None\n",
-      "<HTTPSocketPoolResponse status=200 headers={'content-length': '0', 'content-type': 'text/plain'}>\n"
+      "is_server_live, metadata ()\n",
+      "\n",
+      "live: true\n",
+      "\n"
      ]
     },
     {
@@ -353,7 +280,7 @@
        "True"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -374,26 +301,78 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "POST /v2/repository/index, headers None\n",
+      "get_model_repository_index, metadata ()\n",
       "\n",
-      "<HTTPSocketPoolResponse status=200 headers={'content-type': 'application/json', 'content-length': '62'}>\n",
-      "bytearray(b'[{\"name\":\"criteo\"},{\"name\":\"criteo_nvt\"},{\"name\":\"criteo_tf\"}]')\n"
+      "models {\n",
+      "  name: \"criteo\"\n",
+      "}\n",
+      "models {\n",
+      "  name: \"criteo_nvt\"\n",
+      "}\n",
+      "models {\n",
+      "  name: \"criteo_tf\"\n",
+      "}\n",
+      "models {\n",
+      "  name: \"movielens\"\n",
+      "}\n",
+      "models {\n",
+      "  name: \"movielens_nvt\"\n",
+      "}\n",
+      "models {\n",
+      "  name: \"movielens_tf\"\n",
+      "}\n",
+      "models {\n",
+      "  name: \"rossmann\"\n",
+      "}\n",
+      "models {\n",
+      "  name: \"rossmann_nvt\"\n",
+      "}\n",
+      "models {\n",
+      "  name: \"rossmann_tf\"\n",
+      "}\n",
+      "\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "[{'name': 'criteo'}, {'name': 'criteo_nvt'}, {'name': 'criteo_tf'}]"
+       "models {\n",
+       "  name: \"criteo\"\n",
+       "}\n",
+       "models {\n",
+       "  name: \"criteo_nvt\"\n",
+       "}\n",
+       "models {\n",
+       "  name: \"criteo_tf\"\n",
+       "}\n",
+       "models {\n",
+       "  name: \"movielens\"\n",
+       "}\n",
+       "models {\n",
+       "  name: \"movielens_nvt\"\n",
+       "}\n",
+       "models {\n",
+       "  name: \"movielens_tf\"\n",
+       "}\n",
+       "models {\n",
+       "  name: \"rossmann\"\n",
+       "}\n",
+       "models {\n",
+       "  name: \"rossmann_nvt\"\n",
+       "}\n",
+       "models {\n",
+       "  name: \"rossmann_tf\"\n",
+       "}"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -411,19 +390,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "POST /v2/repository/models/criteo/load, headers None\n",
-      "\n",
-      "<HTTPSocketPoolResponse status=200 headers={'content-type': 'application/json', 'content-length': '0'}>\n",
-      "Loaded model 'criteo'\n",
-      "CPU times: user 0 ns, sys: 3.33 ms, total: 3.33 ms\n",
-      "Wall time: 56.5 s\n"
+      "load_model, metadata ()\n",
+      "model_name: \"criteo\"\n",
+      "\n"
+     ]
+    },
+    {
+     "ename": "InferenceServerException",
+     "evalue": "[StatusCode.UNAVAILABLE] explicit model load / unload is not allowed if polling is enabled",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mInferenceServerException\u001b[0m                  Traceback (most recent call last)",
+      "File \u001b[0;32m<timed eval>:1\u001b[0m, in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n",
+      "File \u001b[0;32m/usr/local/lib/python3.8/dist-packages/tritonclient/grpc/__init__.py:646\u001b[0m, in \u001b[0;36mInferenceServerClient.load_model\u001b[0;34m(self, model_name, headers, config)\u001b[0m\n\u001b[1;32m    644\u001b[0m         \u001b[38;5;28mprint\u001b[39m(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mLoaded model \u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;132;01m{}\u001b[39;00m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;241m.\u001b[39mformat(model_name))\n\u001b[1;32m    645\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m grpc\u001b[38;5;241m.\u001b[39mRpcError \u001b[38;5;28;01mas\u001b[39;00m rpc_error:\n\u001b[0;32m--> 646\u001b[0m     \u001b[43mraise_error_grpc\u001b[49m\u001b[43m(\u001b[49m\u001b[43mrpc_error\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m/usr/local/lib/python3.8/dist-packages/tritonclient/grpc/__init__.py:62\u001b[0m, in \u001b[0;36mraise_error_grpc\u001b[0;34m(rpc_error)\u001b[0m\n\u001b[1;32m     61\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mraise_error_grpc\u001b[39m(rpc_error):\n\u001b[0;32m---> 62\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m get_error_grpc(rpc_error) \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;28mNone\u001b[39m\n",
+      "\u001b[0;31mInferenceServerException\u001b[0m: [StatusCode.UNAVAILABLE] explicit model load / unload is not allowed if polling is enabled"
      ]
     }
    ],
@@ -444,7 +433,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -478,6 +467,7 @@
     "\n",
     "# read in the workflow (to get input/output schema to call triton with)\n",
     "batch_path = os.path.join(BASE_DIR, \"converted/criteo\")\n",
+    "# raise(ValueError(f\"{batch_path}\"))\n",
     "batch = df_lib.read_parquet(os.path.join(batch_path, \"*.parquet\"), num_rows=3)\n",
     "batch = batch[[x for x in batch.columns if x != \"label\"]]\n",
     "print(batch)"
@@ -492,7 +482,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -540,7 +530,7 @@
        "dtype: object"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -551,11 +541,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
-    "import tritonclient.http as httpclient\n",
+    "import tritonclient.grpc as httpclient\n",
     "from tritonclient.utils import np_to_triton_dtype\n",
     "import numpy as np\n",
     "\n",
@@ -580,21 +570,306 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "POST /v2/models/criteo/infer, headers {'Inference-Header-Content-Length': 3382}\n",
-      "b'{\"id\":\"1\",\"inputs\":[{\"name\":\"I1\",\"shape\":[3,1],\"datatype\":\"INT32\",\"parameters\":{\"binary_data_size\":12}},{\"name\":\"I2\",\"shape\":[3,1],\"datatype\":\"INT32\",\"parameters\":{\"binary_data_size\":12}},{\"name\":\"I3\",\"shape\":[3,1],\"datatype\":\"INT32\",\"parameters\":{\"binary_data_size\":12}},{\"name\":\"I4\",\"shape\":[3,1],\"datatype\":\"INT32\",\"parameters\":{\"binary_data_size\":12}},{\"name\":\"I5\",\"shape\":[3,1],\"datatype\":\"INT32\",\"parameters\":{\"binary_data_size\":12}},{\"name\":\"I6\",\"shape\":[3,1],\"datatype\":\"INT32\",\"parameters\":{\"binary_data_size\":12}},{\"name\":\"I7\",\"shape\":[3,1],\"datatype\":\"INT32\",\"parameters\":{\"binary_data_size\":12}},{\"name\":\"I8\",\"shape\":[3,1],\"datatype\":\"INT32\",\"parameters\":{\"binary_data_size\":12}},{\"name\":\"I9\",\"shape\":[3,1],\"datatype\":\"INT32\",\"parameters\":{\"binary_data_size\":12}},{\"name\":\"I10\",\"shape\":[3,1],\"datatype\":\"INT32\",\"parameters\":{\"binary_data_size\":12}},{\"name\":\"I11\",\"shape\":[3,1],\"datatype\":\"INT32\",\"parameters\":{\"binary_data_size\":12}},{\"name\":\"I12\",\"shape\":[3,1],\"datatype\":\"INT32\",\"parameters\":{\"binary_data_size\":12}},{\"name\":\"I13\",\"shape\":[3,1],\"datatype\":\"INT32\",\"parameters\":{\"binary_data_size\":12}},{\"name\":\"C1\",\"shape\":[3,1],\"datatype\":\"INT32\",\"parameters\":{\"binary_data_size\":12}},{\"name\":\"C2\",\"shape\":[3,1],\"datatype\":\"INT32\",\"parameters\":{\"binary_data_size\":12}},{\"name\":\"C3\",\"shape\":[3,1],\"datatype\":\"INT32\",\"parameters\":{\"binary_data_size\":12}},{\"name\":\"C4\",\"shape\":[3,1],\"datatype\":\"INT32\",\"parameters\":{\"binary_data_size\":12}},{\"name\":\"C5\",\"shape\":[3,1],\"datatype\":\"INT32\",\"parameters\":{\"binary_data_size\":12}},{\"name\":\"C6\",\"shape\":[3,1],\"datatype\":\"INT32\",\"parameters\":{\"binary_data_size\":12}},{\"name\":\"C7\",\"shape\":[3,1],\"datatype\":\"INT32\",\"parameters\":{\"binary_data_size\":12}},{\"name\":\"C8\",\"shape\":[3,1],\"datatype\":\"INT32\",\"parameters\":{\"binary_data_size\":12}},{\"name\":\"C9\",\"shape\":[3,1],\"datatype\":\"INT32\",\"parameters\":{\"binary_data_size\":12}},{\"name\":\"C10\",\"shape\":[3,1],\"datatype\":\"INT32\",\"parameters\":{\"binary_data_size\":12}},{\"name\":\"C11\",\"shape\":[3,1],\"datatype\":\"INT32\",\"parameters\":{\"binary_data_size\":12}},{\"name\":\"C12\",\"shape\":[3,1],\"datatype\":\"INT32\",\"parameters\":{\"binary_data_size\":12}},{\"name\":\"C13\",\"shape\":[3,1],\"datatype\":\"INT32\",\"parameters\":{\"binary_data_size\":12}},{\"name\":\"C14\",\"shape\":[3,1],\"datatype\":\"INT32\",\"parameters\":{\"binary_data_size\":12}},{\"name\":\"C15\",\"shape\":[3,1],\"datatype\":\"INT32\",\"parameters\":{\"binary_data_size\":12}},{\"name\":\"C16\",\"shape\":[3,1],\"datatype\":\"INT32\",\"parameters\":{\"binary_data_size\":12}},{\"name\":\"C17\",\"shape\":[3,1],\"datatype\":\"INT32\",\"parameters\":{\"binary_data_size\":12}},{\"name\":\"C18\",\"shape\":[3,1],\"datatype\":\"INT32\",\"parameters\":{\"binary_data_size\":12}},{\"name\":\"C19\",\"shape\":[3,1],\"datatype\":\"INT32\",\"parameters\":{\"binary_data_size\":12}},{\"name\":\"C20\",\"shape\":[3,1],\"datatype\":\"INT32\",\"parameters\":{\"binary_data_size\":12}},{\"name\":\"C21\",\"shape\":[3,1],\"datatype\":\"INT32\",\"parameters\":{\"binary_data_size\":12}},{\"name\":\"C22\",\"shape\":[3,1],\"datatype\":\"INT32\",\"parameters\":{\"binary_data_size\":12}},{\"name\":\"C23\",\"shape\":[3,1],\"datatype\":\"INT32\",\"parameters\":{\"binary_data_size\":12}},{\"name\":\"C24\",\"shape\":[3,1],\"datatype\":\"INT32\",\"parameters\":{\"binary_data_size\":12}},{\"name\":\"C25\",\"shape\":[3,1],\"datatype\":\"INT32\",\"parameters\":{\"binary_data_size\":12}},{\"name\":\"C26\",\"shape\":[3,1],\"datatype\":\"INT32\",\"parameters\":{\"binary_data_size\":12}}],\"outputs\":[{\"name\":\"output\",\"parameters\":{\"binary_data\":true}}]}\\x05\\x00\\x00\\x00 \\x00\\x00\\x00\\x00\\x00\\x00\\x00n\\x00\\x00\\x00\\x03\\x00\\x00\\x00\\xe9\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x05\\x00\\x00\\x00\\x01\\x00\\x00\\x00\\x10\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x92\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x01\\x00\\x00\\x00\\x01\\x00\\x00\\x00\\x01\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x0e\\x00\\x00\\x00=\\x00\\x00\\x00c\\x00\\x00\\x00\\x07\\x00\\x00\\x00\\x05\\x00\\x00\\x00\\x07\\x00\\x00\\x00\\x01\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x01\\x00\\x00\\x00\\x01\\x00\\x00\\x002\\x01\\x00\\x00U\\x0c\\x00\\x00\\x1d\\x0c\\x00\\x00\\x00\\x00\\x00\\x00\\x05\\x00\\x00\\x00\\x01\\x00\\x00\\x00y\\rwb\\x8d\\xfd\\xf3\\xe5y\\rwbX]\\x1f\\xe2\\xa6\\xff\\xaa\\xa0\\x03B\\x98\\xad/D\\xea\\xaf\\xd5\\x15\\xaao\\r\\xc6\\xbeb\\xcf\\x7f\\\\\\x94!4\\x8a\\xda\\xeeIl8H\\'\\xb08#\\x9f\\xd6<M\\x06U\\xe7\\xcbm\\xcdo\\xcbm\\xcdo\\xcbm\\xcdo!\\xaa\\x805\\x81\\xed\\x16\\xabb\\xeb\\xf5\\xb5\\x03\\x89\\x80()lBC\\x8b\\xcc\\xf2\\xd1\\xa6\\xdf\\xdeFT\\xe1\\xf5\\x1d\\x1f\\x82N.\\xc1}\\x02.\\xa9\\xc0\\xe9}\\xc1}\\x02.1B|\\x0cd\\xdcRf1B|\\x0c\\x1f\\x1d\\x98\\x95\\'N\\xeb\\x99\\x84aq\\x12\\xb7\\xff\\xc5\\x00\\xb7\\xff\\xc5\\x00\\xb7\\xff\\xc5\\x007\\xe5N\\xbe7\\xe5N\\xbe7\\xe5N\\xbe\\xcct\\x0b\\x8a\\x99\\xfe\\xbb\\xf3\\x0b\\r\\x0f\\xf7\\xfa>\\xdcL\\xfa>\\xdcL\\xfa>\\xdcL\\xaaV\\x08\\xd2\\xaaV\\x08\\xd2\\xaaV\\x08\\xd2\\xba\\x0b\\x17\\xb8\\x11\\x15\\xeb\\xa1\\x8d\\x1b\\x8fb\\x0b\\xc2\\x12\\x95\\x0b\\xc2\\x12\\x95\\x0b\\xc2\\x12\\x95(/\\x8e\\xc3c\\xd8\\xbf\\xfe(/\\x8e\\xc3]Z\\xf6\\x14\\xa1<2\\xa3]Z\\xf6\\x14\\x89\\xb0\\xb1%V\\xee\\xe1\\xc8\\x89\\xb0\\xb1%\\x0b\\xfc\\xc1\\xd7\\xe8\\xe9R\\x17\\x0b\\xfc\\xc1\\xd7\\x9c`\\xaf|\\x8a\\x0c5u\\x05\\xb9\\xa94\\xfckC0\\xea!\\x13\\x99\\x02He\\xff\\x1dW\\x10\\xedW\\xe9W\\xb7\\x1dW\\x10\\xed'\n",
-      "<HTTPSocketPoolResponse status=200 headers={'content-type': 'application/json', 'inference-header-content-length': '226', 'content-length': '238'}>\n",
-      "bytearray(b'{\"id\":\"1\",\"model_name\":\"criteo\",\"model_version\":\"1\",\"parameters\":{\"sequence_id\":0,\"sequence_start\":false,\"sequence_end\":false},\"outputs\":[{\"name\":\"output\",\"datatype\":\"FP32\",\"shape\":[3,1],\"parameters\":{\"binary_data_size\":12}}]}')\n",
-      "predicted softmax result:\n",
-      " [[0.02414342]\n",
-      " [0.0328052 ]\n",
-      " [0.02708623]]\n"
+      "infer, metadata ()\n",
+      "model_name: \"criteo\"\n",
+      "id: \"1\"\n",
+      "inputs {\n",
+      "  name: \"I1\"\n",
+      "  datatype: \"INT32\"\n",
+      "  shape: 3\n",
+      "  shape: 1\n",
+      "}\n",
+      "inputs {\n",
+      "  name: \"I2\"\n",
+      "  datatype: \"INT32\"\n",
+      "  shape: 3\n",
+      "  shape: 1\n",
+      "}\n",
+      "inputs {\n",
+      "  name: \"I3\"\n",
+      "  datatype: \"INT32\"\n",
+      "  shape: 3\n",
+      "  shape: 1\n",
+      "}\n",
+      "inputs {\n",
+      "  name: \"I4\"\n",
+      "  datatype: \"INT32\"\n",
+      "  shape: 3\n",
+      "  shape: 1\n",
+      "}\n",
+      "inputs {\n",
+      "  name: \"I5\"\n",
+      "  datatype: \"INT32\"\n",
+      "  shape: 3\n",
+      "  shape: 1\n",
+      "}\n",
+      "inputs {\n",
+      "  name: \"I6\"\n",
+      "  datatype: \"INT32\"\n",
+      "  shape: 3\n",
+      "  shape: 1\n",
+      "}\n",
+      "inputs {\n",
+      "  name: \"I7\"\n",
+      "  datatype: \"INT32\"\n",
+      "  shape: 3\n",
+      "  shape: 1\n",
+      "}\n",
+      "inputs {\n",
+      "  name: \"I8\"\n",
+      "  datatype: \"INT32\"\n",
+      "  shape: 3\n",
+      "  shape: 1\n",
+      "}\n",
+      "inputs {\n",
+      "  name: \"I9\"\n",
+      "  datatype: \"INT32\"\n",
+      "  shape: 3\n",
+      "  shape: 1\n",
+      "}\n",
+      "inputs {\n",
+      "  name: \"I10\"\n",
+      "  datatype: \"INT32\"\n",
+      "  shape: 3\n",
+      "  shape: 1\n",
+      "}\n",
+      "inputs {\n",
+      "  name: \"I11\"\n",
+      "  datatype: \"INT32\"\n",
+      "  shape: 3\n",
+      "  shape: 1\n",
+      "}\n",
+      "inputs {\n",
+      "  name: \"I12\"\n",
+      "  datatype: \"INT32\"\n",
+      "  shape: 3\n",
+      "  shape: 1\n",
+      "}\n",
+      "inputs {\n",
+      "  name: \"I13\"\n",
+      "  datatype: \"INT32\"\n",
+      "  shape: 3\n",
+      "  shape: 1\n",
+      "}\n",
+      "inputs {\n",
+      "  name: \"C1\"\n",
+      "  datatype: \"INT32\"\n",
+      "  shape: 3\n",
+      "  shape: 1\n",
+      "}\n",
+      "inputs {\n",
+      "  name: \"C2\"\n",
+      "  datatype: \"INT32\"\n",
+      "  shape: 3\n",
+      "  shape: 1\n",
+      "}\n",
+      "inputs {\n",
+      "  name: \"C3\"\n",
+      "  datatype: \"INT32\"\n",
+      "  shape: 3\n",
+      "  shape: 1\n",
+      "}\n",
+      "inputs {\n",
+      "  name: \"C4\"\n",
+      "  datatype: \"INT32\"\n",
+      "  shape: 3\n",
+      "  shape: 1\n",
+      "}\n",
+      "inputs {\n",
+      "  name: \"C5\"\n",
+      "  datatype: \"INT32\"\n",
+      "  shape: 3\n",
+      "  shape: 1\n",
+      "}\n",
+      "inputs {\n",
+      "  name: \"C6\"\n",
+      "  datatype: \"INT32\"\n",
+      "  shape: 3\n",
+      "  shape: 1\n",
+      "}\n",
+      "inputs {\n",
+      "  name: \"C7\"\n",
+      "  datatype: \"INT32\"\n",
+      "  shape: 3\n",
+      "  shape: 1\n",
+      "}\n",
+      "inputs {\n",
+      "  name: \"C8\"\n",
+      "  datatype: \"INT32\"\n",
+      "  shape: 3\n",
+      "  shape: 1\n",
+      "}\n",
+      "inputs {\n",
+      "  name: \"C9\"\n",
+      "  datatype: \"INT32\"\n",
+      "  shape: 3\n",
+      "  shape: 1\n",
+      "}\n",
+      "inputs {\n",
+      "  name: \"C10\"\n",
+      "  datatype: \"INT32\"\n",
+      "  shape: 3\n",
+      "  shape: 1\n",
+      "}\n",
+      "inputs {\n",
+      "  name: \"C11\"\n",
+      "  datatype: \"INT32\"\n",
+      "  shape: 3\n",
+      "  shape: 1\n",
+      "}\n",
+      "inputs {\n",
+      "  name: \"C12\"\n",
+      "  datatype: \"INT32\"\n",
+      "  shape: 3\n",
+      "  shape: 1\n",
+      "}\n",
+      "inputs {\n",
+      "  name: \"C13\"\n",
+      "  datatype: \"INT32\"\n",
+      "  shape: 3\n",
+      "  shape: 1\n",
+      "}\n",
+      "inputs {\n",
+      "  name: \"C14\"\n",
+      "  datatype: \"INT32\"\n",
+      "  shape: 3\n",
+      "  shape: 1\n",
+      "}\n",
+      "inputs {\n",
+      "  name: \"C15\"\n",
+      "  datatype: \"INT32\"\n",
+      "  shape: 3\n",
+      "  shape: 1\n",
+      "}\n",
+      "inputs {\n",
+      "  name: \"C16\"\n",
+      "  datatype: \"INT32\"\n",
+      "  shape: 3\n",
+      "  shape: 1\n",
+      "}\n",
+      "inputs {\n",
+      "  name: \"C17\"\n",
+      "  datatype: \"INT32\"\n",
+      "  shape: 3\n",
+      "  shape: 1\n",
+      "}\n",
+      "inputs {\n",
+      "  name: \"C18\"\n",
+      "  datatype: \"INT32\"\n",
+      "  shape: 3\n",
+      "  shape: 1\n",
+      "}\n",
+      "inputs {\n",
+      "  name: \"C19\"\n",
+      "  datatype: \"INT32\"\n",
+      "  shape: 3\n",
+      "  shape: 1\n",
+      "}\n",
+      "inputs {\n",
+      "  name: \"C20\"\n",
+      "  datatype: \"INT32\"\n",
+      "  shape: 3\n",
+      "  shape: 1\n",
+      "}\n",
+      "inputs {\n",
+      "  name: \"C21\"\n",
+      "  datatype: \"INT32\"\n",
+      "  shape: 3\n",
+      "  shape: 1\n",
+      "}\n",
+      "inputs {\n",
+      "  name: \"C22\"\n",
+      "  datatype: \"INT32\"\n",
+      "  shape: 3\n",
+      "  shape: 1\n",
+      "}\n",
+      "inputs {\n",
+      "  name: \"C23\"\n",
+      "  datatype: \"INT32\"\n",
+      "  shape: 3\n",
+      "  shape: 1\n",
+      "}\n",
+      "inputs {\n",
+      "  name: \"C24\"\n",
+      "  datatype: \"INT32\"\n",
+      "  shape: 3\n",
+      "  shape: 1\n",
+      "}\n",
+      "inputs {\n",
+      "  name: \"C25\"\n",
+      "  datatype: \"INT32\"\n",
+      "  shape: 3\n",
+      "  shape: 1\n",
+      "}\n",
+      "inputs {\n",
+      "  name: \"C26\"\n",
+      "  datatype: \"INT32\"\n",
+      "  shape: 3\n",
+      "  shape: 1\n",
+      "}\n",
+      "outputs {\n",
+      "  name: \"output\"\n",
+      "}\n",
+      "raw_input_contents: \"\\005\\000\\000\\000 \\000\\000\\000\\000\\000\\000\\000\"\n",
+      "raw_input_contents: \"n\\000\\000\\000\\003\\000\\000\\000\\351\\000\\000\\000\"\n",
+      "raw_input_contents: \"\\000\\000\\000\\000\\005\\000\\000\\000\\001\\000\\000\\000\"\n",
+      "raw_input_contents: \"\\020\\000\\000\\000\\000\\000\\000\\000\\222\\000\\000\\000\"\n",
+      "raw_input_contents: \"\\000\\000\\000\\000\\001\\000\\000\\000\\001\\000\\000\\000\"\n",
+      "raw_input_contents: \"\\001\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\"\n",
+      "raw_input_contents: \"\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\"\n",
+      "raw_input_contents: \"\\016\\000\\000\\000=\\000\\000\\000c\\000\\000\\000\"\n",
+      "raw_input_contents: \"\\007\\000\\000\\000\\005\\000\\000\\000\\007\\000\\000\\000\"\n",
+      "raw_input_contents: \"\\001\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\"\n",
+      "raw_input_contents: \"\\000\\000\\000\\000\\001\\000\\000\\000\\001\\000\\000\\000\"\n",
+      "raw_input_contents: \"2\\001\\000\\000U\\014\\000\\000\\035\\014\\000\\000\"\n",
+      "raw_input_contents: \"\\000\\000\\000\\000\\005\\000\\000\\000\\001\\000\\000\\000\"\n",
+      "raw_input_contents: \"y\\rwb\\215\\375\\363\\345y\\rwb\"\n",
+      "raw_input_contents: \"X]\\037\\342\\246\\377\\252\\240\\003B\\230\\255\"\n",
+      "raw_input_contents: \"/D\\352\\257\\325\\025\\252o\\r\\306\\276b\"\n",
+      "raw_input_contents: \"\\317\\177\\\\\\224!4\\212\\332\\356Il8\"\n",
+      "raw_input_contents: \"H\\'\\2608#\\237\\326<M\\006U\\347\"\n",
+      "raw_input_contents: \"\\313m\\315o\\313m\\315o\\313m\\315o\"\n",
+      "raw_input_contents: \"!\\252\\2005\\201\\355\\026\\253b\\353\\365\\265\"\n",
+      "raw_input_contents: \"\\003\\211\\200()lBC\\213\\314\\362\\321\"\n",
+      "raw_input_contents: \"\\246\\337\\336FT\\341\\365\\035\\037\\202N.\"\n",
+      "raw_input_contents: \"\\301}\\002.\\251\\300\\351}\\301}\\002.\"\n",
+      "raw_input_contents: \"1B|\\014d\\334Rf1B|\\014\"\n",
+      "raw_input_contents: \"\\037\\035\\230\\225\\'N\\353\\231\\204aq\\022\"\n",
+      "raw_input_contents: \"\\267\\377\\305\\000\\267\\377\\305\\000\\267\\377\\305\\000\"\n",
+      "raw_input_contents: \"7\\345N\\2767\\345N\\2767\\345N\\276\"\n",
+      "raw_input_contents: \"\\314t\\013\\212\\231\\376\\273\\363\\013\\r\\017\\367\"\n",
+      "raw_input_contents: \"\\372>\\334L\\372>\\334L\\372>\\334L\"\n",
+      "raw_input_contents: \"\\252V\\010\\322\\252V\\010\\322\\252V\\010\\322\"\n",
+      "raw_input_contents: \"\\272\\013\\027\\270\\021\\025\\353\\241\\215\\033\\217b\"\n",
+      "raw_input_contents: \"\\013\\302\\022\\225\\013\\302\\022\\225\\013\\302\\022\\225\"\n",
+      "raw_input_contents: \"(/\\216\\303c\\330\\277\\376(/\\216\\303\"\n",
+      "raw_input_contents: \"]Z\\366\\024\\241<2\\243]Z\\366\\024\"\n",
+      "raw_input_contents: \"\\211\\260\\261%V\\356\\341\\310\\211\\260\\261%\"\n",
+      "raw_input_contents: \"\\013\\374\\301\\327\\350\\351R\\027\\013\\374\\301\\327\"\n",
+      "raw_input_contents: \"\\234`\\257|\\212\\0145u\\005\\271\\2514\"\n",
+      "raw_input_contents: \"\\374kC0\\352!\\023\\231\\002He\\377\"\n",
+      "raw_input_contents: \"\\035W\\020\\355W\\351W\\267\\035W\\020\\355\"\n",
+      "\n"
+     ]
+    },
+    {
+     "ename": "InferenceServerException",
+     "evalue": "[StatusCode.UNAVAILABLE] Request for unknown model: 'criteo' is not found",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mInferenceServerException\u001b[0m                  Traceback (most recent call last)",
+      "Input \u001b[0;32mIn [11]\u001b[0m, in \u001b[0;36m<cell line: 7>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      2\u001b[0m outputs \u001b[38;5;241m=\u001b[39m [httpclient\u001b[38;5;241m.\u001b[39mInferRequestedOutput(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124moutput\u001b[39m\u001b[38;5;124m\"\u001b[39m)]\n\u001b[1;32m      4\u001b[0m \u001b[38;5;66;03m# build a client to connect to our server.\u001b[39;00m\n\u001b[1;32m      5\u001b[0m \u001b[38;5;66;03m# This InferenceServerClient object is what we'll be using to talk to Triton.\u001b[39;00m\n\u001b[1;32m      6\u001b[0m \u001b[38;5;66;03m# make the request with tritonclient.http.InferInput object\u001b[39;00m\n\u001b[0;32m----> 7\u001b[0m response \u001b[38;5;241m=\u001b[39m \u001b[43mtriton_client\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43minfer\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mcriteo\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43minputs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mrequest_id\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43m1\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43moutputs\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43moutputs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m      9\u001b[0m \u001b[38;5;28mprint\u001b[39m(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mpredicted softmax result:\u001b[39m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[38;5;124m\"\u001b[39m, response\u001b[38;5;241m.\u001b[39mas_numpy(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124moutput\u001b[39m\u001b[38;5;124m\"\u001b[39m))\n",
+      "File \u001b[0;32m/usr/local/lib/python3.8/dist-packages/tritonclient/grpc/__init__.py:1295\u001b[0m, in \u001b[0;36mInferenceServerClient.infer\u001b[0;34m(self, model_name, inputs, model_version, outputs, request_id, sequence_id, sequence_start, sequence_end, priority, timeout, client_timeout, headers, compression_algorithm)\u001b[0m\n\u001b[1;32m   1293\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m result\n\u001b[1;32m   1294\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m grpc\u001b[38;5;241m.\u001b[39mRpcError \u001b[38;5;28;01mas\u001b[39;00m rpc_error:\n\u001b[0;32m-> 1295\u001b[0m     \u001b[43mraise_error_grpc\u001b[49m\u001b[43m(\u001b[49m\u001b[43mrpc_error\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m/usr/local/lib/python3.8/dist-packages/tritonclient/grpc/__init__.py:62\u001b[0m, in \u001b[0;36mraise_error_grpc\u001b[0;34m(rpc_error)\u001b[0m\n\u001b[1;32m     61\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mraise_error_grpc\u001b[39m(rpc_error):\n\u001b[0;32m---> 62\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m get_error_grpc(rpc_error) \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;28mNone\u001b[39m\n",
+      "\u001b[0;31mInferenceServerException\u001b[0m: [StatusCode.UNAVAILABLE] Request for unknown model: 'criteo' is not found"
      ]
     }
    ],
@@ -619,28 +894,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "POST /v2/repository/models/criteo/unload, headers None\n",
-      "\n",
-      "<HTTPSocketPoolResponse status=200 headers={'content-type': 'application/json', 'content-length': '0'}>\n",
-      "Loaded model 'criteo'\n",
-      "POST /v2/repository/models/criteo_nvt/unload, headers None\n",
-      "\n",
-      "<HTTPSocketPoolResponse status=200 headers={'content-type': 'application/json', 'content-length': '0'}>\n",
-      "Loaded model 'criteo_nvt'\n",
-      "POST /v2/repository/models/criteo_tf/unload, headers None\n",
-      "\n",
-      "<HTTPSocketPoolResponse status=200 headers={'content-type': 'application/json', 'content-length': '0'}>\n",
-      "Loaded model 'criteo_tf'\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "triton_client.unload_model(model_name=\"criteo\")\n",
     "triton_client.unload_model(model_name=\"criteo_nvt\")\n",

--- a/tests/integration/common/utils.py
+++ b/tests/integration/common/utils.py
@@ -127,7 +127,7 @@ def _run_query(
 
     inputs = []
     for i, (name, col) in enumerate(columns):
-        d = col.values_host.astype(input_dtypes[name])
+        d = col.fillna(0).values_host.astype(input_dtypes[name])
         d = d.reshape(len(d), 1)
         inputs.append(grpcclient.InferInput(name, d.shape, np_to_triton_dtype(input_dtypes[name])))
         inputs[i].set_data_from_numpy(d)

--- a/tests/integration/test_criteo.py
+++ b/tests/integration/test_criteo.py
@@ -1,0 +1,150 @@
+#
+# Copyright (c) 2021, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+from os.path import dirname, realpath
+
+import pytest
+from testbook import testbook
+
+try:
+    import fastai
+except ImportError:
+    fastai = None
+
+try:
+    import hugectr
+except ImportError:
+    hugectr = None
+
+try:
+    import tensorflow
+except ImportError:
+    tensorflow = None
+
+try:
+    import torch
+except ImportError:
+    torch = None
+
+
+DATA_DIR = os.environ.get("DATASET_DIR", "/raid/data/criteo")
+TEST_PATH = dirname(dirname(realpath(__file__)))
+
+INFERENCE_BASE_DIR = "/model/"
+INFERENCE_MULTI_HOT = os.path.join(INFERENCE_BASE_DIR, "models/")
+
+CRITEO_DIR = "examples/scaling-criteo"
+ROSSMAN_DIR = "examples/tabular-data-rossmann"
+MOVIELENS_DIR = "examples/getting-started-movielens"
+
+allowed_hosts = [
+    "merlin-hugectr",
+    "merlin-tensorflow",
+    "merlin-pytorch",
+]
+
+
+def criteo_base(tmpdir):
+    input_path = os.path.join(DATA_DIR, "tests/crit_int_pq")
+    output_path = os.path.join(tmpdir, "tests/crit_test")
+
+    # Run ETL for all containerss
+    notebook = os.path.join(dirname(TEST_PATH), CRITEO_DIR, "02-ETL-with-NVTabular.ipynb")
+    with testbook(
+        notebook,
+        execute=False,
+        timeout=450,
+    ) as tb_dl_convert:
+        tb_dl_convert.inject(
+            f"""
+                import os
+                os.environ['INPUT_DATA_DIR'] = "{input_path}"
+                os.environ['OUTPUT_DATA_DIR'] = "{output_path}"
+            """
+        )
+        tb_dl_convert.execute_cell(list(range(0, len(tb_dl_convert.cells))))
+
+
+@pytest.mark.skipif(tensorflow is None, reason="tensorflow not installed")
+def test_criteo_tf(asv_db, bench_info, tmpdir, report):
+    criteo_base(tmpdir)
+    output_path = os.path.join(tmpdir, "tests/crit_test")
+
+    notebook = os.path.join(dirname(TEST_PATH), CRITEO_DIR, "03-Training-with-TF.ipynb")
+    with testbook(
+        notebook,
+        execute=False,
+        timeout=450,
+    ) as tb_train_torch:
+        tb_train_torch.inject(
+            f"""
+                import os
+                os.environ['INPUT_DATA_DIR'] = "{output_path}"
+                os.environ['OUTPUT_DATA_DIR'] = "{output_path}"
+            """
+        )
+        tb_train_torch.execute_cell(list(range(0, len(tb_train_torch.cells))))
+
+
+@pytest.mark.skipif(torch is None or fastai is None, reason="pytorch & fastai not installed")
+def test_criteo_fastai(asv_db, bench_info, tmpdir, report):
+    criteo_base(tmpdir)
+    output_path = os.path.join(tmpdir, "tests/crit_test")
+
+    notebook = os.path.join(dirname(TEST_PATH), CRITEO_DIR, "03-Training-with-FastAI.ipynb")
+    with testbook(
+        notebook,
+        execute=False,
+        timeout=450,
+    ) as tb_train_torch:
+        tb_train_torch.inject(
+            f"""
+                import os
+                os.environ['INPUT_DATA_DIR'] = "{output_path}"
+                os.environ['OUTPUT_DATA_DIR'] = "{output_path}"
+            """
+        )
+        tb_train_torch.execute_cell(list(range(0, len(tb_train_torch.cells))))
+
+
+@pytest.mark.skipif(hugectr is None, reason="hugectr not installed")
+def test_criteo_hugectr(asv_db, bench_info, tmpdir, report):
+    criteo_base(tmpdir)
+    output_path = os.path.join(tmpdir, "tests/crit_test")
+
+    notebook = os.path.join(dirname(TEST_PATH), CRITEO_DIR, "03-Training-with-HugeCTR.ipynb")
+
+    with testbook(
+        notebook,
+        execute=False,
+        timeout=450,
+    ) as tb_train_torch:
+        tb_train_torch.inject(
+            f"""
+                import os
+                os.environ['INPUT_DATA_DIR'] = "{output_path}"
+                os.environ['OUTPUT_DATA_DIR'] = "{output_path}"
+            """
+        )
+        tb_train_torch.execute_cell(list(range(0, len(tb_train_torch.cells))))
+
+
+# out = _run_notebook(tmpdir, notebook, output_path, output_path, gpu_id="0", clean_up=False)
+# notebook = os.path.join(
+#     dirname(TEST_PATH), CRITEO_DIR, "04-Triton-Inference-with-HugeCTR.ipynb"
+# )
+# _run_notebook(tmpdir, notebook, input_path, output_path, gpu_id="0", clean_up=False)

--- a/tests/integration/test_criteo.py
+++ b/tests/integration/test_criteo.py
@@ -16,6 +16,12 @@
 
 import os
 from os.path import dirname, realpath
+from distutils.spawn import find_executable
+from common.utils import _run_query
+import tests.conftest as test_utils
+import cudf
+import glob
+import nvtabular as nvt
 
 import pytest
 from testbook import testbook
@@ -43,8 +49,9 @@ except ImportError:
 
 DATA_DIR = os.environ.get("DATASET_DIR", "/raid/data/criteo")
 TEST_PATH = dirname(dirname(realpath(__file__)))
+TRITON_SERVER_PATH = find_executable("tritonserver")
 
-INFERENCE_BASE_DIR = "/model/"
+INFERENCE_BASE_DIR = os.environ.get("INFERENCE_BASE_DIR", "/tmp/model/")
 INFERENCE_MULTI_HOT = os.path.join(INFERENCE_BASE_DIR, "models/")
 
 CRITEO_DIR = "examples/scaling-criteo"
@@ -61,7 +68,7 @@ allowed_hosts = [
 def criteo_base(tmpdir):
     input_path = os.path.join(DATA_DIR, "tests/crit_int_pq")
     output_path = os.path.join(tmpdir, "tests/crit_test")
-
+    os.makedirs(output_path)
     # Run ETL for all containerss
     notebook = os.path.join(dirname(TEST_PATH), CRITEO_DIR, "02-ETL-with-NVTabular.ipynb")
     with testbook(
@@ -82,7 +89,11 @@ def criteo_base(tmpdir):
 @pytest.mark.skipif(tensorflow is None, reason="tensorflow not installed")
 def test_criteo_tf(asv_db, bench_info, tmpdir, report):
     criteo_base(tmpdir)
+    input_path = os.path.join(DATA_DIR, "tests/crit_int_pq")
     output_path = os.path.join(tmpdir, "tests/crit_test")
+    # inference_path = os.path.join(output_path, "models")
+    # os.makedirs(inference_path)
+    os.environ["MODEL_BASE_DIR"] = INFERENCE_MULTI_HOT
 
     notebook = os.path.join(dirname(TEST_PATH), CRITEO_DIR, "03-Training-with-TF.ipynb")
     with testbook(
@@ -98,6 +109,44 @@ def test_criteo_tf(asv_db, bench_info, tmpdir, report):
             """
         )
         tb_train_torch.execute_cell(list(range(0, len(tb_train_torch.cells))))
+
+    notebook = os.path.join(
+        dirname(TEST_PATH), CRITEO_DIR, "04-Triton-Inference-with-TF.ipynb"
+    )
+    with testbook(
+        notebook,
+        execute=False,
+        timeout=450,
+    ) as tb_infer:
+        tb_infer.inject(
+            f"""
+                import os
+                os.environ['INPUT_DATA_DIR'] = "{output_path}"
+                os.environ['OUTPUT_DATA_DIR'] = "{output_path}"
+            """
+        )
+        tb_infer.execute_cell(list(range(0, 16)))
+    with test_utils.run_triton_server(
+        INFERENCE_MULTI_HOT,
+        "criteo",
+        TRITON_SERVER_PATH,
+        str(0),
+        "tensorflow",
+    ) as client:
+        with testbook(
+            notebook,
+            execute=False,
+            timeout=450,
+        ) as tb_infer:
+            tb_infer.inject(
+                f"""
+                    import os
+                    os.environ['INPUT_DATA_DIR'] = "{output_path}"
+                    os.environ['OUTPUT_DATA_DIR'] = "{output_path}"
+                """
+            )
+            tb_infer.execute_cell(list(range(19, len(tb_infer.cells))))
+
 
 
 @pytest.mark.skipif(torch is None or fastai is None, reason="pytorch & fastai not installed")
@@ -124,6 +173,7 @@ def test_criteo_fastai(asv_db, bench_info, tmpdir, report):
 @pytest.mark.skipif(hugectr is None, reason="hugectr not installed")
 def test_criteo_hugectr(asv_db, bench_info, tmpdir, report):
     criteo_base(tmpdir)
+    input_path = os.path.join(DATA_DIR, "tests/crit_int_pq")
     output_path = os.path.join(tmpdir, "tests/crit_test")
 
     notebook = os.path.join(dirname(TEST_PATH), CRITEO_DIR, "03-Training-with-HugeCTR.ipynb")
@@ -132,19 +182,95 @@ def test_criteo_hugectr(asv_db, bench_info, tmpdir, report):
         notebook,
         execute=False,
         timeout=450,
-    ) as tb_train_torch:
-        tb_train_torch.inject(
+    ) as tb_train:
+        tb_train.inject(
             f"""
                 import os
                 os.environ['INPUT_DATA_DIR'] = "{output_path}"
                 os.environ['OUTPUT_DATA_DIR'] = "{output_path}"
             """
         )
-        tb_train_torch.execute_cell(list(range(0, len(tb_train_torch.cells))))
+        tb_train.execute_cell(list(range(0, len(tb_train.cells))))
 
+
+    notebook = os.path.join(
+        dirname(TEST_PATH), CRITEO_DIR, "04-Triton-Inference-with-HugeCTR.ipynb"
+    )
+
+    with testbook(
+        notebook,
+        execute=False,
+        timeout=450,
+    ) as tb_infer:
+        tb_infer.inject(
+            f"""
+                import os
+                os.environ['INPUT_DATA_DIR'] = "{output_path}"
+                os.environ['OUTPUT_DATA_DIR'] = "{output_path}"
+            """
+        )
+        tb_infer.execute_cell(list(range(0, 16)))
+    write_ps_file()
+    with test_utils.run_triton_server(
+        INFERENCE_BASE_DIR,
+        "criteo",
+        TRITON_SERVER_PATH,
+        str(0),
+        "hugectr",
+        ps_path="/tmp/model/ps.json",
+    ) as client:
+        with testbook(
+            notebook,
+            execute=False,
+            timeout=450,
+        ) as tb_infer:
+            tb_infer.inject(
+                f"""
+                    import os
+                    os.environ['BASE_DIR'] = "{DATA_DIR}"
+                    os.environ['INPUT_DATA_DIR'] = "{output_path}"
+                    os.environ['OUTPUT_DATA_DIR'] = "{output_path}"
+                    import numpy as np
+                """
+            )
+            tb_infer.execute_cell(list(range(18, len(tb_infer.cells))))
 
 # out = _run_notebook(tmpdir, notebook, output_path, output_path, gpu_id="0", clean_up=False)
 # notebook = os.path.join(
 #     dirname(TEST_PATH), CRITEO_DIR, "04-Triton-Inference-with-HugeCTR.ipynb"
 # )
 # _run_notebook(tmpdir, notebook, input_path, output_path, gpu_id="0", clean_up=False)
+
+def write_ps_file():
+    import json
+    config = json.dumps(
+        {
+            "supportlonglong": "true",
+            "models": [
+                {
+                    "model": "criteo",
+                    "sparse_files": ["/tmp/model/criteo/1/0_sparse_9600.model"],
+                    "dense_file": "/tmp/model/criteo/1/_dense_9600.model",
+                    "network_file": "/tmp/model/criteo/1/criteo.json",
+                    "max_batch_size": "64",
+                    "gpucache": "true",
+                    "hit_rate_threshold": "0.9",
+                    "gpucacheper": "0.5",
+                    "num_of_worker_buffer_in_pool": "4",
+                    "num_of_refresher_buffer_in_pool": "1",
+                    "cache_refresh_percentage_per_iteration": 0.2,
+                    "deployed_device_list": ["0"],
+                    "default_value_for_each_table": ["0.0", "0.0"],
+                    "maxnum_catfeature_query_per_table_per_sample":[2, 26],
+                    "embedding_vecsize_per_table": [16 for x in range(26)],
+                }
+            ],
+        }
+    )
+
+
+    config = json.loads(config)
+    with open("/tmp/model/ps.json", "w", encoding="utf-8") as f:
+        json.dump(config, f)
+
+

--- a/tests/integration/test_movielens.py
+++ b/tests/integration/test_movielens.py
@@ -16,9 +16,13 @@
 
 import os
 from os.path import dirname, realpath
+from distutils.spawn import find_executable
 
 import pytest
 from testbook import testbook
+from common.utils import _run_query
+import tests.conftest as test_utils
+
 
 try:
     import torch
@@ -39,6 +43,8 @@ INFERENCE_MULTI_HOT = os.path.join(INFERENCE_BASE_DIR, "models/")
 CRITEO_DIR = "examples/scaling-criteo"
 ROSSMAN_DIR = "examples/tabular-data-rossmann"
 MOVIELENS_DIR = "examples/getting-started-movielens"
+TRITON_SERVER_PATH = find_executable("tritonserver")
+
 
 allowed_hosts = [
     "merlin-hugectr",
@@ -122,6 +128,17 @@ def test_movielens_tf(asv_db, bench_info, tmpdir, devices):
             """
         )
         tb_train_tf.execute_cell(list(range(0, len(tb_train_tf.cells))))
+    create_movielens_inference_data(INFERENCE_MULTI_HOT, DATA_DIR, input_path, 100)
+    with test_utils.run_triton_server(
+        INFERENCE_MULTI_HOT,
+        "movielens",
+        TRITON_SERVER_PATH,
+        str(0),
+        "tensorflow",
+    ) as client:
+        diff, run_time = _run_movielens_query(client, 3, INFERENCE_MULTI_HOT,input_path )
+
+        assert (diff < 0.00001).all()
 
 
 @pytest.mark.skipif(torch is None, reason="pytorch not installed")
@@ -153,3 +170,79 @@ def test_movielens_torch(asv_db, bench_info, tmpdir, devices):
             """
         )
         tb_train_torch.execute_cell(list(range(0, len(tb_train_torch.cells))))
+
+
+
+def create_movielens_inference_data(model_dir, data_dir, output_dir, nrows):
+    from tensorflow import keras
+    import nvtabular as nvt
+    import cudf
+    import glob
+
+    from nvtabular.loader.tensorflow import KerasSequenceLoader
+
+    workflow_path = os.path.join(os.path.expanduser(model_dir), "movielens_nvt/1/workflow")
+    model_path = os.path.join(os.path.expanduser(model_dir), "movielens_tf/1/model.savedmodel")
+    data_path = os.path.join(os.path.expanduser(data_dir), "movielens/data/valid.parquet")
+    output_dir = os.path.join(os.path.expanduser(output_dir), "movielens/")
+    os.makedirs(output_dir)
+    workflow_output_test_file_name = "test_inference_movielens_data.csv"
+    workflow_output_test_trans_file_name = "test_inference_movielens_data_trans.parquet"
+    prediction_file_name = "movielens_predictions.csv"
+
+    workflow = nvt.Workflow.load(workflow_path)
+
+    sample_data = cudf.read_parquet(data_path, nrows=nrows)
+    sample_data.to_csv(os.path.join(output_dir, workflow_output_test_file_name))
+    sample_data_trans = nvt.workflow.workflow._transform_partition(
+        sample_data, [workflow.output_node]
+    )
+    sample_data_trans.to_parquet(os.path.join(output_dir, workflow_output_test_trans_file_name))
+
+    CATEGORICAL_COLUMNS = ["movieId", "userId"]  # Single-hot
+    CATEGORICAL_MH_COLUMNS = ["genres"]  # Multi-hot
+    NUMERIC_COLUMNS = []
+
+    test_data_trans_path = glob.glob(os.path.join(output_dir, workflow_output_test_trans_file_name))
+
+    train_dataset = KerasSequenceLoader(
+        test_data_trans_path,  # you could also use a glob pattern
+        batch_size=nrows,
+        label_names=[],
+        cat_names=CATEGORICAL_COLUMNS + CATEGORICAL_MH_COLUMNS,
+        cont_names=NUMERIC_COLUMNS,
+        engine="parquet",
+        shuffle=False,
+        buffer_size=0.06,  # how many batches to load at once
+        parts_per_chunk=1,
+    )
+
+    tf_model = keras.models.load_model(model_path)
+
+    pred = tf_model.predict(train_dataset)
+    cudf_pred = cudf.DataFrame(pred)
+    cudf_pred.to_csv(os.path.join(output_dir, prediction_file_name))
+
+    os.remove(os.path.join(output_dir, workflow_output_test_trans_file_name))
+
+def _run_movielens_query(client, n_rows, model_dir, output_dir):
+    workflow_path = os.path.join(os.path.expanduser(model_dir), "movielens_nvt/1/workflow")
+    data_path = os.path.join(
+        os.path.expanduser(output_dir), "movielens/test_inference_movielens_data.csv"
+    )
+    actual_output_filename = os.path.join(
+        os.path.expanduser(output_dir), "movielens/movielens_predictions.csv"
+    )
+
+    input_col_names = ["movieId", "userId"]
+    return _run_query(
+        client,
+        n_rows,
+        "movielens",
+        workflow_path,
+        data_path,
+        actual_output_filename,
+        "output",
+        input_col_names,
+    )
+

--- a/tests/integration/test_movielens.py
+++ b/tests/integration/test_movielens.py
@@ -1,0 +1,155 @@
+#
+# Copyright (c) 2021, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+from os.path import dirname, realpath
+
+import pytest
+from testbook import testbook
+
+try:
+    import torch
+except ImportError:
+    torch = None
+
+try:
+    import tensorflow
+except ImportError:
+    tensorflow = None
+
+DATA_DIR = os.environ.get("DATASET_DIR", "/raid/data/")
+TEST_PATH = dirname(dirname(realpath(__file__)))
+
+INFERENCE_BASE_DIR = "/model/"
+INFERENCE_MULTI_HOT = os.path.join(INFERENCE_BASE_DIR, "models/")
+
+CRITEO_DIR = "examples/scaling-criteo"
+ROSSMAN_DIR = "examples/tabular-data-rossmann"
+MOVIELENS_DIR = "examples/getting-started-movielens"
+
+allowed_hosts = [
+    "merlin-hugectr",
+    "merlin-tensorflow",
+    "merlin-pytorch",
+]
+
+
+def movielens_base(tmpdir):
+    data_path = os.path.join(DATA_DIR, "movielens/data")
+    input_path = os.path.join(tmpdir, "movielens/input")
+    os.makedirs(input_path)
+    os.environ["BASE_DIR"] = INFERENCE_BASE_DIR
+    os.environ["MODEL_NAME_NVT"] = "movielens_nvt"
+    os.environ["MODEL_NAME_TF"] = "movielens_tf"
+    os.environ["MODEL_NAME_ENSEMBLE"] = "movielens"
+    os.environ["MODEL_BASE_DIR"] = INFERENCE_MULTI_HOT
+    os.environ["MODEL_PATH"] = INFERENCE_MULTI_HOT
+
+    # Run Tensorflow or PyTorch
+    # Run Download & Convert for all
+    notebook = os.path.join(dirname(TEST_PATH), MOVIELENS_DIR, "01-Download-Convert.ipynb")
+
+    with testbook(
+        notebook,
+        execute=False,
+        timeout=450,
+    ) as tb_dl_convert:
+        tb_dl_convert.inject(
+            f"""
+                import os
+                os.environ['INPUT_DATA_DIR'] = "{data_path}"
+                os.environ['OUTPUT_DATA_DIR'] = "{input_path}"
+            """
+        )
+        tb_dl_convert.execute_cell(list(range(0, len(tb_dl_convert.cells))))
+
+    # _run_notebook(tmpdir, notebook, data_path, input_path, gpu_id=devices, clean_up=False)
+
+    # Run ETL for all
+    notebook = os.path.join(dirname(TEST_PATH), MOVIELENS_DIR, "02-ETL-with-NVTabular.ipynb")
+    with testbook(
+        notebook,
+        execute=False,
+        timeout=450,
+    ) as tb_nvt:
+        tb_nvt.inject(
+            f"""
+                import os
+                os.environ['INPUT_DATA_DIR'] = "{data_path}"
+                os.environ['OUTPUT_DATA_DIR'] = "{input_path}"
+            """
+        )
+        tb_nvt.execute_cell(list(range(0, len(tb_nvt.cells))))
+
+
+@pytest.mark.skipif(tensorflow is None, reason="tensorflow not installed")
+def test_movielens_tf(asv_db, bench_info, tmpdir, devices):
+    movielens_base(tmpdir)
+
+    data_path = os.path.join(DATA_DIR, "movielens/data")
+    input_path = os.path.join(tmpdir, "movielens/input")
+    os.environ["BASE_DIR"] = INFERENCE_BASE_DIR
+    os.environ["MODEL_NAME_NVT"] = "movielens_nvt"
+    os.environ["MODEL_NAME_TF"] = "movielens_tf"
+    os.environ["MODEL_NAME_ENSEMBLE"] = "movielens"
+    os.environ["MODEL_BASE_DIR"] = INFERENCE_MULTI_HOT
+    os.environ["MODEL_PATH"] = INFERENCE_MULTI_HOT
+
+    notebook = os.path.join(dirname(TEST_PATH), MOVIELENS_DIR, "03-Training-with-TF.ipynb")
+    with testbook(
+        notebook,
+        execute=False,
+        timeout=450,
+    ) as tb_train_tf:
+        tb_train_tf.inject(
+            f"""
+                import os
+                os.environ['INPUT_DATA_DIR'] = "{data_path}"
+                os.environ['OUTPUT_DATA_DIR'] = "{input_path}"
+            """
+        )
+        tb_train_tf.execute_cell(list(range(0, len(tb_train_tf.cells))))
+
+
+@pytest.mark.skipif(torch is None, reason="pytorch not installed")
+def test_movielens_torch(asv_db, bench_info, tmpdir, devices):
+    movielens_base(tmpdir)
+
+    data_path = os.path.join(DATA_DIR, "movielens/data")
+    input_path = os.path.join(tmpdir, "movielens/input")
+    os.environ["BASE_DIR"] = INFERENCE_BASE_DIR
+    os.environ["MODEL_NAME_NVT"] = "movielens_nvt"
+    os.environ["MODEL_NAME_TF"] = "movielens_tf"
+    os.environ["MODEL_NAME_ENSEMBLE"] = "movielens"
+    os.environ["MODEL_BASE_DIR"] = INFERENCE_MULTI_HOT
+    os.environ["MODEL_PATH"] = INFERENCE_MULTI_HOT
+
+    # _run_notebook(tmpdir, notebook, data_path, input_path, gpu_id=devices, clean_up=False)
+    notebook = os.path.join(dirname(TEST_PATH), MOVIELENS_DIR, "03-Training-with-PyTorch.ipynb")
+
+    with testbook(
+        notebook,
+        execute=False,
+        timeout=450,
+    ) as tb_train_torch:
+        tb_train_torch.inject(
+            f"""
+                import os
+                os.environ['INPUT_DATA_DIR'] = "{data_path}"
+                os.environ['OUTPUT_DATA_DIR'] = "{input_path}"
+            """
+        )
+        tb_train_torch.execute_cell(list(range(0, len(tb_train_torch.cells))))

--- a/tests/integration/test_movielens.py
+++ b/tests/integration/test_movielens.py
@@ -15,14 +15,14 @@
 #
 
 import os
-from os.path import dirname, realpath
 from distutils.spawn import find_executable
+from os.path import dirname, realpath
 
 import pytest
-from testbook import testbook
 from common.utils import _run_query
-import tests.conftest as test_utils
+from testbook import testbook
 
+import tests.conftest as test_utils
 
 try:
     import torch
@@ -37,7 +37,7 @@ except ImportError:
 DATA_DIR = os.environ.get("DATASET_DIR", "/raid/data/")
 TEST_PATH = dirname(dirname(realpath(__file__)))
 
-INFERENCE_BASE_DIR = "/model/"
+INFERENCE_BASE_DIR = "/tmp/model/"
 INFERENCE_MULTI_HOT = os.path.join(INFERENCE_BASE_DIR, "models/")
 
 CRITEO_DIR = "examples/scaling-criteo"
@@ -136,7 +136,7 @@ def test_movielens_tf(asv_db, bench_info, tmpdir, devices):
         str(0),
         "tensorflow",
     ) as client:
-        diff, run_time = _run_movielens_query(client, 3, INFERENCE_MULTI_HOT,input_path )
+        diff, run_time = _run_movielens_query(client, 3, INFERENCE_MULTI_HOT, input_path)
 
         assert (diff < 0.00001).all()
 
@@ -172,13 +172,13 @@ def test_movielens_torch(asv_db, bench_info, tmpdir, devices):
         tb_train_torch.execute_cell(list(range(0, len(tb_train_torch.cells))))
 
 
-
 def create_movielens_inference_data(model_dir, data_dir, output_dir, nrows):
-    from tensorflow import keras
-    import nvtabular as nvt
-    import cudf
     import glob
 
+    import cudf
+    from tensorflow import keras
+
+    import nvtabular as nvt
     from nvtabular.loader.tensorflow import KerasSequenceLoader
 
     workflow_path = os.path.join(os.path.expanduser(model_dir), "movielens_nvt/1/workflow")
@@ -225,6 +225,7 @@ def create_movielens_inference_data(model_dir, data_dir, output_dir, nrows):
 
     os.remove(os.path.join(output_dir, workflow_output_test_trans_file_name))
 
+
 def _run_movielens_query(client, n_rows, model_dir, output_dir):
     workflow_path = os.path.join(os.path.expanduser(model_dir), "movielens_nvt/1/workflow")
     data_path = os.path.join(
@@ -245,4 +246,3 @@ def _run_movielens_query(client, n_rows, model_dir, output_dir):
         "output",
         input_col_names,
     )
-

--- a/tests/integration/test_nvt_hugectr.py
+++ b/tests/integration/test_nvt_hugectr.py
@@ -31,12 +31,10 @@ try:
 except ImportError:
     hugectr = None
 
-import warnings
 from distutils.spawn import find_executable
 
 import numpy as np
 import pandas as pd
-from common.parsers.benchmark_parsers import create_bench_result
 from common.utils import _run_query
 from sklearn.model_selection import train_test_split
 
@@ -50,11 +48,11 @@ DIR = "/model/"
 DATA_DIR = DIR + "data/"
 TEMP_DIR = DIR + "temp_hugectr/"
 MODEL_DIR = DIR + "models/"
-TRAIN_DIR = MODEL_DIR + "test_model/1/"
+TRAIN_DIR = MODEL_DIR + "hugectr/1/"
 NETWORK_FILE = TRAIN_DIR + "model.json"
 DENSE_FILE = TRAIN_DIR + "_dense_1900.model"
 SPARSE_FILES = TRAIN_DIR + "0_sparse_1900.model"
-MODEL_NAME = "test_model"
+MODEL_NAME = "hugectr"
 
 CATEGORICAL_COLUMNS = ["userId", "movieId", "new_cat1"]
 LABEL_COLUMNS = ["rating"]
@@ -64,7 +62,9 @@ TRITON_SERVER_PATH = find_executable("tritonserver")
 TRITON_DEVICE_ID = "1"
 
 
-def test_training():
+@pytest.mark.parametrize("n_rows", [64])
+@pytest.mark.parametrize("err_tol", [0.00001])
+def test_hugectr(n_rows, err_tol):
     # Download & Convert data
     download_file(
         "http://files.grouplens.org/datasets/movielens/ml-25m.zip",
@@ -167,7 +167,7 @@ def test_training():
     for files in file_names:
         shutil.move(files, TEMP_DIR)
 
-    hugectr_params = dict()
+    hugectr_params = {}
     hugectr_params["config"] = NETWORK_FILE
     hugectr_params["slots"] = len(slot_sizes)
     hugectr_params["max_nnz"] = len(slot_sizes)
@@ -188,15 +188,9 @@ def test_training():
     shutil.rmtree(TEMP_DIR)
     _predict(dense_features, embedding_columns, row_ptrs, hugectr_params["config"], MODEL_NAME)
 
-
-@pytest.mark.parametrize("n_rows", [64, 58, 11, 1])
-@pytest.mark.parametrize("err_tol", [0.00001])
-def test_inference(n_rows, err_tol):
-    warnings.simplefilter("ignore")
-
-    data_path = DATA_DIR + "test/data.csv"
-    output_path = DATA_DIR + "test/output.csv"
-    ps_file = TRAIN_DIR + "ps.json"
+    data_path = test_data_path + "data.csv"
+    output_path = test_data_path + "output.csv"
+    ps_file = MODEL_DIR + "ps.json"
 
     workflow_path = MODEL_DIR + MODEL_NAME + "_nvt/1/workflow"
 
@@ -222,11 +216,11 @@ def test_inference(n_rows, err_tol):
             "hugectr",
         )
     assert (diff < err_tol).all()
-    benchmark_results = []
-    result = create_bench_result(
-        "test_nvt_hugectr_inference", [("n_rows", n_rows)], run_time, "datetime"
-    )
-    benchmark_results.append(result)
+    # benchmark_results = []
+    # result = create_bench_result(
+    #     "test_nvt_hugectr_inference", [("n_rows", n_rows)], run_time, "datetime"
+    # )
+    # benchmark_results.append(result)
     # send_results(asv_db, bench_info, benchmark_results)
 
 
@@ -389,11 +383,18 @@ def _write_ps_hugectr(output_file, model_name, sparse_files, dense_file, network
                     "sparse_files": [sparse_files],
                     "dense_file": dense_file,
                     "network_file": network_file,
+                    "max_batch_size": 64,
+                    "hit_rate_threshold": 0.9,
+                    "gpucacheper": 0.5,
+                    "deployed_device_list": [0],
+                    "default_value_for_each_table": [0.0, 0.0],
+                    "maxnum_catfeature_query_per_table_per_sample": [2, 26],
+                    "embedding_vecsize_per_table": [1, 15],
                 }
             ],
         }
     )
 
     config = json.loads(config)
-    with open(output_file, "w") as f:
+    with open(output_file, "w", encoding="utf-8") as f:
         json.dump(config, f)

--- a/tests/integration/test_rossman.py
+++ b/tests/integration/test_rossman.py
@@ -16,6 +16,12 @@
 
 import os
 from os.path import dirname, realpath
+from distutils.spawn import find_executable
+from common.utils import _run_query
+import tests.conftest as test_utils
+import cudf
+import glob
+import nvtabular as nvt
 
 import pytest
 from testbook import testbook
@@ -37,6 +43,7 @@ except ImportError:
 
 DATA_DIR = os.environ.get("DATASET_DIR", "/raid/data/")
 TEST_PATH = dirname(dirname(realpath(__file__)))
+TRITON_SERVER_PATH = find_executable("tritonserver")
 
 INFERENCE_BASE_DIR = "/model/"
 INFERENCE_MULTI_HOT = os.path.join(INFERENCE_BASE_DIR, "models/")
@@ -116,6 +123,18 @@ def test_rossman_tf(asv_db, bench_info, tmpdir, devices, report):
             """
         )
         tb_training.execute_cell(list(range(0, len(tb_training.cells))))
+    create_rossman_inference_data(INFERENCE_MULTI_HOT, DATA_DIR, output_path, 100)
+    with test_utils.run_triton_server(
+        INFERENCE_MULTI_HOT,
+        "rossmann",
+        TRITON_SERVER_PATH,
+        str(0),
+        "tensorflow",
+    ) as client:
+        diff, run_time = _run_rossmann_query(client, 3, INFERENCE_MULTI_HOT, output_path)
+
+        assert (diff < 0.00001).all()
+
 
 
 @pytest.mark.skipif(torch is None, reason="pytorch not installed")
@@ -170,3 +189,138 @@ def test_rossman_fastai(asv_db, bench_info, tmpdir, devices, report):
             """
         )
         tb_training.execute_cell(list(range(0, len(tb_training.cells))))
+
+
+def create_rossman_inference_data(model_dir, data_dir, output_dir, nrows):
+    import tensorflow as tf
+    from tensorflow import keras
+
+    from nvtabular.loader.tensorflow import KerasSequenceLoader
+
+    workflow_path = os.path.join(os.path.expanduser(model_dir), "rossmann_nvt/1/workflow")
+    model_path = os.path.join(os.path.expanduser(model_dir), "rossmann_tf/1/model.savedmodel")
+    data_path = os.path.join(os.path.expanduser(data_dir), "rossman/input/valid.csv")
+    output_dir = os.path.join(os.path.expanduser(output_dir), "rossman/")
+    os.makedirs(output_dir)
+    workflow_output_test_file_name = "test_inference_rossmann_data.csv"
+    workflow_output_test_trans_file_name = "test_inference_rossmann_data_trans.parquet"
+    prediction_file_name = "rossmann_predictions.csv"
+
+    workflow = nvt.Workflow.load(workflow_path)
+
+    sample_data = cudf.read_csv(data_path, nrows=nrows)
+    sample_data.to_csv(os.path.join(output_dir, workflow_output_test_file_name))
+    sample_data_trans = nvt.workflow.workflow._transform_partition(
+        sample_data, [workflow.output_node]
+    )
+    sample_data_trans.to_parquet(os.path.join(output_dir, workflow_output_test_trans_file_name))
+
+    CATEGORICAL_COLUMNS = [
+        "Store",
+        "DayOfWeek",
+        "Year",
+        "Month",
+        "Day",
+        "StateHoliday",
+        "CompetitionMonthsOpen",
+        "Promo2Weeks",
+        "StoreType",
+        "Assortment",
+        "PromoInterval",
+        "CompetitionOpenSinceYear",
+        "Promo2SinceYear",
+        "State",
+        "Week",
+        "Events",
+        "Promo_fw",
+        "Promo_bw",
+        "StateHoliday_fw",
+        "StateHoliday_bw",
+        "SchoolHoliday_fw",
+        "SchoolHoliday_bw",
+    ]
+
+    CONTINUOUS_COLUMNS = [
+        "CompetitionDistance",
+        "Max_TemperatureC",
+        "Mean_TemperatureC",
+        "Min_TemperatureC",
+        "Max_Humidity",
+        "Mean_Humidity",
+        "Min_Humidity",
+        "Max_Wind_SpeedKm_h",
+        "Mean_Wind_SpeedKm_h",
+        "CloudCover",
+        "trend",
+        "trend_DE",
+        "AfterStateHoliday",
+        "BeforeStateHoliday",
+        "Promo",
+        "SchoolHoliday",
+    ]
+
+    test_data_trans_path = glob.glob(os.path.join(output_dir, workflow_output_test_trans_file_name))
+    EMBEDDING_TABLE_SHAPES = nvt.ops.get_embedding_sizes(workflow)
+
+    categorical_columns = [
+        _make_categorical_embedding_column(name, *EMBEDDING_TABLE_SHAPES[name])
+        for name in CATEGORICAL_COLUMNS
+    ]
+    continuous_columns = [
+        tf.feature_column.numeric_column(name, (1,)) for name in CONTINUOUS_COLUMNS
+    ]
+
+    train_dataset = KerasSequenceLoader(
+        test_data_trans_path,  # you could also use a glob pattern
+        feature_columns=categorical_columns + continuous_columns,
+        batch_size=nrows,
+        label_names=[],
+        shuffle=False,
+        buffer_size=0.06,  # amount of data, as a fraction of GPU memory, to load at once
+    )
+
+    tf_model = keras.models.load_model(model_path, custom_objects={"rmspe_tf": rmspe_tf})
+
+    pred = tf_model.predict(train_dataset)
+    cudf_pred = cudf.DataFrame(pred)
+    cudf_pred.to_csv(os.path.join(output_dir, prediction_file_name))
+
+    os.remove(os.path.join(output_dir, workflow_output_test_trans_file_name))
+
+
+
+def _run_rossmann_query(client, n_rows, model_dir, output_dir):
+    workflow_path = os.path.join(os.path.expanduser(model_dir), "rossmann_nvt/1/workflow")
+    data_path = os.path.join(
+        os.path.expanduser(output_dir), "rossman/test_inference_rossmann_data.csv"
+    )
+    actual_output_filename = os.path.join(
+        os.path.expanduser(output_dir), "rossman/rossmann_predictions.csv"
+    )
+    return _run_query(
+        client,
+        n_rows,
+        "rossmann",
+        workflow_path,
+        data_path,
+        actual_output_filename,
+        "tf.math.multiply_1",
+    )
+
+
+
+def _make_categorical_embedding_column(name, dictionary_size, embedding_dim):
+    import tensorflow as tf
+
+    return tf.feature_column.embedding_column(
+        tf.feature_column.categorical_column_with_identity(name, dictionary_size), embedding_dim
+    )
+
+def rmspe_tf(y_true, y_pred):
+    import tensorflow as tf
+
+    y_true = tf.exp(y_true) - 1
+    y_pred = tf.exp(y_pred) - 1
+
+    percent_error = (y_true - y_pred) / y_true
+    return tf.sqrt(tf.reduce_mean(percent_error ** 2))

--- a/tests/integration/test_rossman.py
+++ b/tests/integration/test_rossman.py
@@ -1,0 +1,172 @@
+#
+# Copyright (c) 2021, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+from os.path import dirname, realpath
+
+import pytest
+from testbook import testbook
+
+try:
+    import torch
+except ImportError:
+    torch = None
+
+try:
+    import fastai
+except ImportError:
+    fastai = None
+
+try:
+    import tensorflow
+except ImportError:
+    tensorflow = None
+
+DATA_DIR = os.environ.get("DATASET_DIR", "/raid/data/")
+TEST_PATH = dirname(dirname(realpath(__file__)))
+
+INFERENCE_BASE_DIR = "/model/"
+INFERENCE_MULTI_HOT = os.path.join(INFERENCE_BASE_DIR, "models/")
+
+CRITEO_DIR = "examples/scaling-criteo"
+ROSSMAN_DIR = "examples/tabular-data-rossmann"
+MOVIELENS_DIR = "examples/getting-started-movielens"
+
+allowed_hosts = [
+    "merlin-hugectr",
+    "merlin-tensorflow",
+    "merlin-pytorch",
+]
+
+
+def rossman_base(tmpdir):
+    data_path = os.path.join(DATA_DIR, "rossman/data")
+    input_path = os.path.join(tmpdir, "rossman/input")
+    os.makedirs(input_path)
+
+    # Run Downloa   d & Convert for all
+    notebook = os.path.join(dirname(TEST_PATH), ROSSMAN_DIR, "01-Download-Convert.ipynb")
+    with testbook(
+        notebook,
+        execute=False,
+        timeout=450,
+    ) as tb_dl_convert:
+        tb_dl_convert.inject(
+            f"""
+                import os
+                os.environ['INPUT_DATA_DIR'] = "{data_path}"
+                os.environ['OUTPUT_DATA_DIR'] = "{input_path}"
+            """
+        )
+        tb_dl_convert.execute_cell(list(range(0, len(tb_dl_convert.cells))))
+    # out = _run_notebook(tmpdir, notebook, data_path, input_path, gpu_id=devices, clean_up=False)
+
+    # Run ETL for all
+    notebook = os.path.join(dirname(TEST_PATH), ROSSMAN_DIR, "02-ETL-with-NVTabular.ipynb")
+    with testbook(
+        notebook,
+        execute=False,
+        timeout=450,
+    ) as tb_nvt:
+        tb_nvt.inject(
+            f"""
+                import os
+                os.environ['INPUT_DATA_DIR'] = "{data_path}"
+                os.environ['OUTPUT_DATA_DIR'] = "{input_path}"
+            """
+        )
+        tb_nvt.execute_cell(list(range(0, len(tb_nvt.cells))))
+
+
+@pytest.mark.skipif(tensorflow is None, reason="tensorflow not installed")
+def test_rossman_tf(asv_db, bench_info, tmpdir, devices, report):
+    rossman_base(tmpdir)
+    input_path = os.path.join(tmpdir, "rossman/input")
+    output_path = os.path.join(tmpdir, "rossman/output")
+    os.makedirs(output_path)
+
+    os.environ["BASE_DIR"] = INFERENCE_BASE_DIR
+
+    # Run training for PyTorch container
+    notebook = os.path.join(dirname(TEST_PATH), ROSSMAN_DIR, "03-Training-with-TF.ipynb")
+
+    with testbook(
+        notebook,
+        execute=False,
+        timeout=450,
+    ) as tb_training:
+        tb_training.inject(
+            f"""
+                import os
+                os.environ['INPUT_DATA_DIR'] = "{input_path}"
+                os.environ['OUTPUT_DATA_DIR'] = "{output_path}"
+            """
+        )
+        tb_training.execute_cell(list(range(0, len(tb_training.cells))))
+
+
+@pytest.mark.skipif(torch is None, reason="pytorch not installed")
+def test_rossman_torch(asv_db, bench_info, tmpdir, devices, report):
+    rossman_base(tmpdir)
+    input_path = os.path.join(tmpdir, "rossman/input")
+    output_path = os.path.join(tmpdir, "rossman/output")
+    os.makedirs(output_path)
+
+    os.environ["BASE_DIR"] = INFERENCE_BASE_DIR
+
+    # Run training for PyTorch container
+    notebook = os.path.join(dirname(TEST_PATH), ROSSMAN_DIR, "03-Training-with-TF.ipynb")
+
+    with testbook(
+        notebook,
+        execute=False,
+        timeout=450,
+    ) as tb_training:
+        tb_training.inject(
+            f"""
+                import os
+                os.environ['INPUT_DATA_DIR'] = "{input_path}"
+                os.environ['OUTPUT_DATA_DIR'] = "{output_path}"
+            """
+        )
+        tb_training.execute_cell(list(range(0, len(tb_training.cells))))
+
+
+@pytest.mark.skipif(torch is None or fastai is None, reason="pytorch & fastai not installed")
+def test_rossman_fastai(asv_db, bench_info, tmpdir, devices, report):
+    rossman_base(tmpdir)
+    input_path = os.path.join(tmpdir, "rossman/input")
+    output_path = os.path.join(tmpdir, "rossman/output")
+    os.makedirs(output_path)
+
+    os.environ["BASE_DIR"] = INFERENCE_BASE_DIR
+
+    # Run training for PyTorch container
+    notebook = os.path.join(dirname(TEST_PATH), ROSSMAN_DIR, "03-Training-with-FastAI.ipynb")
+
+    with testbook(
+        notebook,
+        execute=False,
+        timeout=450,
+    ) as tb_training:
+        tb_training.inject(
+            f"""
+                import os
+                os.environ['INPUT_DATA_DIR'] = "{input_path}"
+                os.environ['OUTPUT_DATA_DIR'] = "{input_path}"
+            """
+        )
+        tb_training.execute_cell(list(range(0, len(tb_training.cells))))


### PR DESCRIPTION
Band-aid to get the integration tests we already have working again after long hiatus. 

- [ ] refactor to use testbooks
- [ ] remove old test modules
- [ ] ensure writing happens to user controlled directories.