### PR TITLE
Remove unnecessary docs dependencies

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -44,7 +44,6 @@ extensions = [
     "sphinx_external_toc",
     "sphinx_multiversion",
     "sphinx_rtd_theme",
-    "sphinx_markdown_tables",
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
     "sphinx.ext.coverage",
@@ -66,7 +65,7 @@ myst_enable_extensions = [
 ]
 myst_linkify_fuzzy_links = False
 myst_heading_anchors = 3
-jupyter_execute_notebooks = "off"
+nb_execution_mode = "off"
 
 # The API documents are RST and include `.. toctree::` directives.
 suppress_warnings = ["etoc.toctree", "myst.header", "misc.highlighting_failure"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,6 @@ click<8.1.0
 flake8==3.9.2
 ipython_genutils
 isort==5.9.3
-nbsphinx>=0.6
 pylint==2.7.4
 bandit==1.7.0
 flake8-nb==0.3.0
@@ -25,14 +24,13 @@ interrogate==1.5.0
 Sphinx<3.6
 jinja2<3.1
 markupsafe==2.0.1
-sphinx_markdown_tables==0.0.15
 sphinx-multiversion@git+https://github.com/mikemckiernan/sphinx-multiversion.git
 sphinxcontrib-copydirs@git+https://github.com/mikemckiernan/sphinxcontrib-copydirs.git
 sphinx-external-toc<0.4
 sphinx_rtd_theme
-natsort<8.2
-myst-nb<0.14
-linkify-it-py<1.1
+natsort
+myst-nb
+linkify-it-py
 
 # needed to make test_s3 work
 pytest-xdist


### PR DESCRIPTION
We don't seem to need sphinx_markdown_tables.
I also loosened the versions of some dependencies
because, at the moment, I don't have a reason to
restrict them.