### PR TITLE
fix tritonserver gpu id & fixed timeout for criteo integration tests

### DIFF
--- a/tests/integration/test_criteo.py
+++ b/tests/integration/test_criteo.py
@@ -71,7 +71,7 @@ def criteo_base(tmpdir):
     with testbook(
         notebook,
         execute=False,
-        timeout=450,
+        timeout=3600,
     ) as tb_dl_convert:
         tb_dl_convert.inject(
             f"""
@@ -92,7 +92,7 @@ def test_criteo_fastai(asv_db, bench_info, tmpdir, report):
     with testbook(
         notebook,
         execute=False,
-        timeout=450,
+        timeout=3600,
     ) as tb_train_torch:
         tb_train_torch.inject(
             f"""
@@ -116,7 +116,7 @@ def test_criteo_tf(asv_db, bench_info, tmpdir, report):
     with testbook(
         notebook,
         execute=False,
-        timeout=450,
+        timeout=3600,
     ) as tb_train_torch:
         tb_train_torch.inject(
             f"""
@@ -173,7 +173,7 @@ def test_criteo_hugectr(asv_db, bench_info, tmpdir, report):
     with testbook(
         notebook,
         execute=False,
-        timeout=450,
+        timeout=3600,
     ) as tb_train:
         tb_train.inject(
             f"""

--- a/tests/integration/test_nvt_hugectr.py
+++ b/tests/integration/test_nvt_hugectr.py
@@ -59,7 +59,7 @@ LABEL_COLUMNS = ["rating"]
 TEST_N_ROWS = 64
 
 TRITON_SERVER_PATH = find_executable("tritonserver")
-TRITON_DEVICE_ID = "1"
+TRITON_DEVICE_ID = "0"
 
 
 @pytest.mark.parametrize("n_rows", [64])


### PR DESCRIPTION
Increases timeout on criteo because we have to account for more of dataset, so it takes more time. Added correct "0" gpu to account for blossom only supporting one GPU per job.