### PR TITLE
skip download step, that is not allowed in CI

### DIFF
--- a/tests/integration/test_movielens.py
+++ b/tests/integration/test_movielens.py
@@ -95,7 +95,7 @@ def movielens_base(tmpdir):
         tb_nvt.inject(
             f"""
                 import os
-                os.environ['INPUT_DATA_DIR'] = "{data_path}"
+                os.environ['INPUT_DATA_DIR'] = "{input_path}"
                 os.environ['OUTPUT_DATA_DIR'] = "{input_path}"
             """
         )
@@ -106,7 +106,6 @@ def movielens_base(tmpdir):
 def test_movielens_tf(asv_db, bench_info, tmpdir, devices):
     movielens_base(tmpdir)
 
-    data_path = os.path.join(DATA_DIR, "movielens-25m")
     input_path = os.path.join(tmpdir, "movielens/input")
     os.environ["BASE_DIR"] = INFERENCE_BASE_DIR
     os.environ["MODEL_NAME_NVT"] = "movielens_nvt"
@@ -124,7 +123,7 @@ def test_movielens_tf(asv_db, bench_info, tmpdir, devices):
         tb_train_tf.inject(
             f"""
                 import os
-                os.environ['INPUT_DATA_DIR'] = "{data_path}"
+                os.environ['INPUT_DATA_DIR'] = "{input_path}"
                 os.environ['OUTPUT_DATA_DIR'] = "{input_path}"
             """
         )
@@ -146,7 +145,6 @@ def test_movielens_tf(asv_db, bench_info, tmpdir, devices):
 def test_movielens_torch(asv_db, bench_info, tmpdir, devices):
     movielens_base(tmpdir)
 
-    data_path = os.path.join(DATA_DIR, "movielens-25m")
     input_path = os.path.join(tmpdir, "movielens/input")
     os.environ["BASE_DIR"] = INFERENCE_BASE_DIR
     os.environ["MODEL_NAME_NVT"] = "movielens_nvt"
@@ -166,7 +164,7 @@ def test_movielens_torch(asv_db, bench_info, tmpdir, devices):
         tb_train_torch.inject(
             f"""
                 import os
-                os.environ['INPUT_DATA_DIR'] = "{data_path}"
+                os.environ['INPUT_DATA_DIR'] = "{input_path}"
                 os.environ['OUTPUT_DATA_DIR'] = "{input_path}"
             """
         )

--- a/tests/integration/test_movielens.py
+++ b/tests/integration/test_movielens.py
@@ -80,7 +80,8 @@ def movielens_base(tmpdir):
                 os.environ['OUTPUT_DATA_DIR'] = "{input_path}"
             """
         )
-        tb_dl_convert.execute_cell(list(range(0, len(tb_dl_convert.cells))))
+        tb_dl_convert.execute_cell(list(range(0, 7)))
+        tb_dl_convert.execute_cell(list(range(8, len(tb_dl_convert.cells))))
 
     # _run_notebook(tmpdir, notebook, data_path, input_path, gpu_id=devices, clean_up=False)
 

--- a/tests/integration/test_rossman.py
+++ b/tests/integration/test_rossman.py
@@ -92,7 +92,7 @@ def rossman_base(tmpdir):
         tb_nvt.inject(
             f"""
                 import os
-                os.environ['INPUT_DATA_DIR'] = "{data_path}"
+                os.environ['INPUT_DATA_DIR'] = "{input_path}"
                 os.environ['OUTPUT_DATA_DIR'] = "{input_path}"
             """
         )
@@ -322,4 +322,4 @@ def rmspe_tf(y_true, y_pred):
     y_pred = tf.exp(y_pred) - 1
 
     percent_error = (y_true - y_pred) / y_true
-    return tf.sqrt(tf.reduce_mean(percent_error ** 2))
+    return tf.sqrt(tf.reduce_mean(percent_error**2))

--- a/tests/integration/test_rossman.py
+++ b/tests/integration/test_rossman.py
@@ -322,4 +322,4 @@ def rmspe_tf(y_true, y_pred):
     y_pred = tf.exp(y_pred) - 1
 
     percent_error = (y_true - y_pred) / y_true
-    return tf.sqrt(tf.reduce_mean(percent_error**2))
+    return tf.sqrt(tf.reduce_mean(percent_error ** 2))


### PR DESCRIPTION
Skips download step for data in the movielens notebooks. This will prevent errors during testing because we cannot write to directory where data is located.
