### PR TITLE
Fix groupby on lists with cudf 22.06+

### DIFF
--- a/nvtabular/ops/groupby.py
+++ b/nvtabular/ops/groupby.py
@@ -298,8 +298,8 @@ def _first(x):
     # item in the list
     if hasattr(x, "list"):
         # cuDF-specific behavior
-        offsets = x.list._column.offsets
-        elements = x.list._column.elements
+        offsets = x.list._column.offsets.values
+        elements = x.list._column.elements.values
         return elements[offsets[:-1]]
     else:
         # cpu/pandas
@@ -311,9 +311,9 @@ def _last(x):
     # item in the list
     if hasattr(x, "list"):
         # cuDF-specific behavior
-        offsets = x.list._column.offsets
-        elements = x.list._column.elements
-        return elements[offsets[1:].values - 1]
+        offsets = x.list._column.offsets.values
+        elements = x.list._column.elements.values
+        return elements[offsets[1:] - 1]
     else:
         # cpu/pandas
         return x.apply(lambda y: y[-1])

--- a/nvtabular/ops/groupby.py
+++ b/nvtabular/ops/groupby.py
@@ -299,8 +299,8 @@ def _first(x):
     if hasattr(x, "list"):
         # cuDF-specific behavior
         offsets = x.list._column.offsets.values
-        elements = x.list._column.elements.values
-        return elements[offsets[:-1]]
+        elements = x.list.leaves
+        return elements[offsets[:-1]]._column
     else:
         # cpu/pandas
         return x.apply(lambda y: y[0])
@@ -312,8 +312,8 @@ def _last(x):
     if hasattr(x, "list"):
         # cuDF-specific behavior
         offsets = x.list._column.offsets.values
-        elements = x.list._column.elements.values
-        return elements[offsets[1:] - 1]
+        elements = x.list.leaves
+        return elements[offsets[1:] - 1]._column
     else:
         # cpu/pandas
         return x.apply(lambda y: y[-1])


### PR DESCRIPTION
Groupby unittests are failing on cudf 22.06+ with an error like

```
FAILED tests/unit/ops/test_groupyby.py::test_groupby_op[id-True-False] - TypeError: 'NumericalColumn' object is not subscriptable
```

Fix.

