### PR TITLE
chore: Add pybind11 as a tox requirement

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@
 
 [tox]
 envlist = python3.8,test-gpu,test-cpu
+requires = pybind11
 
 [testenv]
 commands =


### PR DESCRIPTION
To avoid asking developers to install pybind11
on their host or mixing virtual envs with tox,
it seems simplest to make pybind11 a requirement
before tox attempts to create any environment.