### PR TITLE
adding import or skip for tensorflow framework required by examples

### DIFF
--- a/tests/unit/examples/test_01-Getting-started.py
+++ b/tests/unit/examples/test_01-Getting-started.py
@@ -14,10 +14,12 @@
 # limitations under the License.
 #
 import nest_asyncio
+import pytest
 from testbook import testbook
 
 from tests.conftest import REPO_ROOT
 
+pytest.importorskip("tensorflow")
 nest_asyncio.apply()
 
 

--- a/tests/unit/examples/test_02-Advanced-NVTabular-workflow.py
+++ b/tests/unit/examples/test_02-Advanced-NVTabular-workflow.py
@@ -20,6 +20,7 @@ from testbook import testbook
 from tests.conftest import REPO_ROOT
 
 pytest.importorskip("cudf")
+pytest.importorskip("tensorflow")
 nest_asyncio.apply()
 
 


### PR DESCRIPTION
This PR adds an import or skip for the example tests that rely on the tensorflow framework. These tests should not run when tensorflow is not present.