### PR TITLE
remove test references that are no longer available

### DIFF
--- a/ci/test_integration.sh
+++ b/ci/test_integration.sh
@@ -29,11 +29,3 @@ cd /nvtabular/
 container=$1
 config="-rsx --devices $2"
 
-# Run tests for training containers
-pytest $config tests/integration/test_criteo.py
-pytest $config tests/integration/test_movielens.py
-
-# Run tests for specific containers
-if [ "$container" == "merlin-hugectr" ]; then
-  pytest $config tests/integration/test_nvt_hugectr.py
-fi


### PR DESCRIPTION
The test_integration script references integration tests that no longer exist. Thus integration testing fails on nvtabular because of "missing" files. We have removed those test references... now integration testing script is empty but will still be available so that we have a placeholder to fill in when new integration tests are defined.