### PR TITLE
Fix output error occurring due to  check if it is a dict or not

### DIFF
--- a/nvtabular/inference/triton/model/model_pt.py
+++ b/nvtabular/inference/triton/model/model_pt.py
@@ -157,9 +157,7 @@ class TritonPythonModel:
 
                 # Call forward function to get the predictions
                 # Forward function should return a dict with the "predictions" bucket
-                out = self.model(input_dict, training=False)
-                # Get the predictions from the out
-                pred = out
+                pred = self.model(input_dict, training=False)
                 if pred is None:
                     raise KeyError(
                         "output of the forward function should have a bucket named as predictions"

--- a/nvtabular/inference/triton/model/model_pt.py
+++ b/nvtabular/inference/triton/model/model_pt.py
@@ -158,11 +158,11 @@ class TritonPythonModel:
                 # Call forward function to get the predictions
                 # Forward function should return a dict with the "predictions" bucket
                 out = self.model(input_dict, training=False)
-                if not isinstance(out, dict):
-                    raise ValueError("output of the forward function should be a dict")
+                # if not isinstance(out, dict):
+                # raise ValueError("output of the forward function should be a dict")
 
                 # Get the predictions from the out
-                pred = out.get("predictions")
+                pred = out
                 if pred is None:
                     raise KeyError(
                         "output of the forward function should have a bucket named as predictions"

--- a/nvtabular/inference/triton/model/model_pt.py
+++ b/nvtabular/inference/triton/model/model_pt.py
@@ -158,9 +158,6 @@ class TritonPythonModel:
                 # Call forward function to get the predictions
                 # Forward function should return a dict with the "predictions" bucket
                 out = self.model(input_dict, training=False)
-                # if not isinstance(out, dict):
-                # raise ValueError("output of the forward function should be a dict")
-
                 # Get the predictions from the out
                 pred = out
                 if pred is None:


### PR DESCRIPTION
The Transformers4Rrec [end-to-end example](https://github.com/NVIDIA-Merlin/Transformers4Rec/blob/main/examples/end-to-end-session-based/02-End-to-end-session-based-with-Yoochoose-PyT.ipynb) gives an error `Failed to process the request(s) for model 'mymodel_pt', message: ValueError: output of the forward function should be a dict` when we send request to TIS. the reason for that is due to recent changes in the prediction tasks' outputs in TF4Rec repo (see https://github.com/NVIDIA-Merlin/Transformers4Rec/pull/546). This PR provides a quick fix to avoid such error. However, for long term solution Oliver's draft PR (see https://github.com/NVIDIA-Merlin/systems/pull/252) might be preferable. 