### PR TITLE
Replace `flake8` with `ruff` (which is equivalent but faster)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,14 +5,14 @@ repos:
     hooks:
       - id: absolufy-imports
   - repo: https://github.com/timothycrosley/isort
-    rev: 5.10.1
+    rev: 5.11.4
     hooks:
     - id: isort
       additional_dependencies: [toml]
       exclude: examples/.*
   # code style
   - repo: https://github.com/python/black
-    rev: 22.6.0
+    rev: 22.12.0
     hooks:
     - id: black
   - repo: https://github.com/charliermarsh/ruff-pre-commit
@@ -22,7 +22,7 @@ repos:
         # Respect `exclude` and `extend-exclude` settings.
         args: ["--force-exclude"]  
   - repo: https://github.com/pycqa/pylint
-    rev: v2.14.1
+    rev: v2.15.9
     hooks:
     - id: pylint
   # notebooks
@@ -40,7 +40,7 @@ repos:
       exclude: ^(docs|bench|examples|tests|setup.py|versioneer.py)
       args: [--config=pyproject.toml]
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.1
+    rev: v2.2.2
     hooks:
     - id: codespell
       exclude: .github/.*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,14 +15,16 @@ repos:
     rev: 22.6.0
     hooks:
     - id: black
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: 'v0.0.208'
+    hooks:
+      - id: ruff
+        # Respect `exclude` and `extend-exclude` settings.
+        args: ["--force-exclude"]  
   - repo: https://github.com/pycqa/pylint
     rev: v2.14.1
     hooks:
     - id: pylint
-  - repo: https://github.com/pycqa/flake8
-    rev: 3.9.2
-    hooks:
-    - id: flake8
   # notebooks
   - repo: https://github.com/s-weigand/flake8-nb
     rev: v0.5.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,27 @@ build-backend = "setuptools.build_meta"
 [tool.black]
 line-length = 100
 
+[tool.ruff]
+exclude = [
+    'build',
+    '.eggs',
+    '*_pb2.py',
+]
+ignore = ['B905']
+line-length = 100
+select = [
+	'A', 'B', 'E', 'F', 'N', 'Q', 'S', 'W', 'C4', 'T10',
+	'BLE', 'DTZ', 'PGH', 'PLC', 'PLE', 'PLR', 'PLW', 'SIM', 'TID', 'YTT',
+	'RUF100'
+]
+
+[tool.ruff.per-file-ignores]
+"examples/criteo_benchmark.py" = ['E402']
+"examples/dataloader_bench.py" = ['E402']
+
+[tool.ruff.pydocstyle]
+convention = "numpy"
+
 [tool.isort]
 use_parentheses = true
 multi_line_output = 3

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,11 +1,3 @@
-[flake8]
-max-line-length = 100
-exclude = build,.eggs,*_pb2.py
-ignore = E203,W503
-per-file-ignores =
-    examples/criteo_benchmark.py:E402
-    examples/dataloader_bench.py:E402
-
 [flake8_nb]
 max-line-length = 120
 ignore = E203,E402,W503


### PR DESCRIPTION
`ruff` is a very fast Python linter written in Rust that covers the flake8 rules in addition to a bunch of other popular linters. This sets up a config for it that covers the existing flake8 config, and adds additional linters while generating minimal errors with the existing code base. Since `pylint` is much slower than `ruff` (and I suspect slower than `flake8` too), this config executes the `ruff` checks first in order to fail fast.