### PR TITLE
add gcp label to jenkinsfile

### DIFF
--- a/ci/pr.gpu.Jenkinsfile
+++ b/ci/pr.gpu.Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent {
         docker {
             image 'nvcr.io/nvstaging/merlin/merlin-ci-runner-wrapper'
-            label 'merlin_gpu'
+            label 'merlin_gpu_gcp || merlin_gpu'
             registryCredentialsId 'jawe-nvcr-io'
             registryUrl 'https://nvcr.io'
             args "--runtime=nvidia -e NVIDIA_VISIBLE_DEVICES=all --shm-size '256m'"


### PR DESCRIPTION
This adds the label for GCP a100 nodes to be used on gpuci.io to run PR gpu tests