### PR TITLE
add tf gpu allocator env var to tox

### DIFF
--- a/tests/unit/examples/test_02-Advanced-NVTabular-workflow.py
+++ b/tests/unit/examples/test_02-Advanced-NVTabular-workflow.py
@@ -84,19 +84,19 @@ def test_example_02_advanced_workflow():
         metrics = tb.ref("metrics")
         assert set(metrics.history.keys()) == set(
             [
-                "auc_1",
+                "auc",
                 "binary_accuracy",
                 "loss",
                 "loss_batch",
-                "precision_1",
-                "recall_1",
+                "precision",
+                "recall",
                 "regularization_loss",
-                "val_auc_1",
+                "val_auc",
                 "val_binary_accuracy",
                 "val_loss",
                 "val_loss_batch",
-                "val_precision_1",
-                "val_recall_1",
+                "val_precision",
+                "val_recall",
                 "val_regularization_loss",
             ]
         )

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,8 @@ commands =
     python -m pytest --cov-report term --cov=merlin -rxs tests/unit
 
 [testenv:test-gpu]
+setenv = 
+    TF_GPU_ALLOCATOR=cuda_malloc_async
 passenv =
     OPAL_PREFIX NR_USER
 sitepackages=true


### PR DESCRIPTION
adds global env var to ensure all tensorflow imports only allocate the required memory and release after use.