### PR TITLE
fix gpu visibilty issues on privileged container

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -29,6 +29,7 @@ setenv =
     TF_GPU_ALLOCATOR=cuda_malloc_async
 passenv =
     OPAL_PREFIX NR_USER
+    CUDA_VISIBLE_DEVICES
 sitepackages=true
 ; Runs in: Internal Jenkins
 ; Runs GPU-based tests.


### PR DESCRIPTION
This PR works to fix issues with gpu usage even when more gpus are available on a given docker container. By setting this we can keep all testing artifacts on the desired GPUs. 