### PR TITLE
docs: Rebuild on push

### DIFF
--- a/.github/workflows/docs-sched-rebuild.yaml
+++ b/.github/workflows/docs-sched-rebuild.yaml
@@ -1,9 +1,9 @@
 name: docs-sched-rebuild
 
 on:
-  schedule:
-    # * is a special character in YAML so you have to quote this string
-    - cron: "0 0 * * *"
+  branches: [main]
+  tags:
+    - v*
   workflow_dispatch:
 
 jobs:

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ Follow the instructions below to build the docs.
    ```shell
    python3 -m vevn .venv
    source .venv/bin/activate
+   python -m pip install -U pip tox
    tox -e docs
    ```
 


### PR DESCRIPTION
Before Merlin had many, many repositories, we had dozens of merges in the NVT repo each day.  Rebuilding the docs after each push--at that time--seemed wasteful and I opted to rebuild nightly.  Time passed and now the load is spread across repos and rebuilding after a push to the default branch is more efficient than a scheduled build.

Also clarify the steps for building docs locally.