### PR TITLE
Fix docs tox environment

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,7 @@ Follow the instructions below to build the docs.
 
    This runs Sphinx in your shell and outputs to `docs/build/html/`.
 
-   > **Note:** Your virtual environment should use Python 3.9, not 3.10+:
+   > **Note:** Currently, we lock our Sphinx version to 3.6, which doesn't support Python 3.10. If you're using Python 3.10, install an earlier version of Python to build the docs:
    >
    > ```shell
    > sudo apt update

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,13 +12,22 @@ Follow the instructions below to build the docs.
 1. To build the docs, you need to install a developer environment and run `tox`:
 
    ```shell
-   python3 -m vevn .venv
+   python3 -m venv .venv
    source .venv/bin/activate
    python -m pip install -U pip tox
    tox -e docs
    ```
 
    This runs Sphinx in your shell and outputs to `docs/build/html/`.
+
+    > **Note:** Your virtual environment should use Python 3.9, not 3.10+:
+    >
+    > ```shell
+    > sudo apt update
+    > sudo apt install python3.9-venv
+    > sudo apt install python3.9-dev
+    > python3.9 -m venv .venv
+    > ```
 
 1. Start an HTTP server and review your updates:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,14 +20,14 @@ Follow the instructions below to build the docs.
 
    This runs Sphinx in your shell and outputs to `docs/build/html/`.
 
-    > **Note:** Your virtual environment should use Python 3.9, not 3.10+:
-    >
-    > ```shell
-    > sudo apt update
-    > sudo apt install python3.9-venv
-    > sudo apt install python3.9-dev
-    > python3.9 -m venv .venv
-    > ```
+   > **Note:** Your virtual environment should use Python 3.9, not 3.10+:
+   >
+   > ```shell
+   > sudo apt update
+   > sudo apt install python3.9-venv
+   > sudo apt install python3.9-dev
+   > python3.9 -m venv .venv
+   > ```
 
 1. Start an HTTP server and review your updates:
 

--- a/tox.ini
+++ b/tox.ini
@@ -79,6 +79,7 @@ commands =
 changedir = {toxinidir}
 deps = -rrequirements/docs.txt
 commands =
+    python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/core.git@{posargs:main}
     python -m sphinx.cmd.build -P -b {posargs:html} docs/source docs/build/{posargs:html}
 
 [testenv:docs-multi]

--- a/tox.ini
+++ b/tox.ini
@@ -79,7 +79,7 @@ commands =
 changedir = {toxinidir}
 deps = -rrequirements/docs.txt
 commands =
-    python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/core.git@{posargs:main}
+    python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/core.git
     python -m sphinx.cmd.build -P -b {posargs:html} docs/source docs/build/{posargs:html}
 
 [testenv:docs-multi]

--- a/tox.ini
+++ b/tox.ini
@@ -79,7 +79,7 @@ commands =
 changedir = {toxinidir}
 deps = -rrequirements/docs.txt
 commands =
-    python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/core.git
+    python -m pip install .
     python -m sphinx.cmd.build -P -b {posargs:html} docs/source docs/build/{posargs:html}
 
 [testenv:docs-multi]


### PR DESCRIPTION
The [API documentation](https://nvidia-merlin.github.io/NVTabular/main/api.html) was empty because `autosummary` couldn't import the source modules. I fixed this by installing `merlin-core` in the docs tox environment.

> **Note:** When I generate the docs now, I see some import warnings for other packages. However, I opted to ignore those for now because I was having trouble installing one of them (cudf) into the environment, and it didn't prevent the docs from generating.

I've also included a couple of small README changes:

- Fixed a typo
- Added a note about using Python 3.9 to generate documentation