### PR TITLE
Enable `Workflow.transform` to be run with a DataFrame type

### DIFF
--- a/nvtabular/workflow/workflow.py
+++ b/nvtabular/workflow/workflow.py
@@ -32,6 +32,7 @@ except ImportError:
     cudf = None
 import pandas as pd
 
+from merlin.core.dispatch import DataFrameType
 from merlin.dag import Graph
 from merlin.dag.executors import DaskExecutor, LocalExecutor
 from merlin.dag.node import iter_nodes
@@ -78,9 +79,7 @@ class Workflow:
         self.graph = Graph(output_node)
         self.executor = DaskExecutor(client)
 
-    def transform(
-        self, dataset: Union[Dataset, "cudf.DataFrame", pd.DataFrame]
-    ) -> Union[Dataset, "cudf.DataFrame", pd.DataFrame]:
+    def transform(self, dataset: Union[Dataset, DataFrameType]) -> Union[Dataset, DataFrameType]:
         """Transforms the dataset by applying the graph of operators to it. Requires the ``fit``
         method to have already been called, or calculated statistics to be loaded from disk
 

--- a/nvtabular/workflow/workflow.py
+++ b/nvtabular/workflow/workflow.py
@@ -96,7 +96,15 @@ class Workflow:
         Dataset
             Transformed Dataset with the workflow graph applied to it
         """
-        return self._transform_impl(dataset)
+        if isinstance(dataset, Dataset):
+            return self._transform_impl(dataset)
+        elif isinstance(dataset, pd.DataFrame) or (cudf and isinstance(dataset, cudf.DataFrame)):
+            return self._transform_df(dataset)
+        else:
+            raise ValueError(
+                "Workflow.transform received an unsupported type: {type(dataset)} "
+                "Supported types are a `merlin.io.Dataset` or DataFrame (pandas or cudf)"
+            )
 
     def fit_schema(self, input_schema: Schema):
         """Computes input and output schemas for each node in the Workflow graph

--- a/nvtabular/workflow/workflow.py
+++ b/nvtabular/workflow/workflow.py
@@ -81,25 +81,36 @@ class Workflow:
 
     @singledispatchmethod
     def transform(self, data):
-        """Transforms the dataset by applying the graph of operators to it. Requires the ``fit``
-        method to have already been called, or calculated statistics to be loaded from disk
+        """Transforms the data by applying the graph of operators to it.
 
-        This method returns a Dataset object, with the transformations lazily loaded. None
-        of the actual computation will happen until the produced Dataset is consumed, or
-        written out to disk.
+        Requires the ``fit`` method to have already been called, or
+        using a Workflow that has already beeen fit and re-loaded from
+        disk (using the ``load`` method).
+
+        This method returns data of the same type.
+
+        In the case of a `Dataset`. The computation is lazy. It won't
+        happen until the produced Dataset is consumed, or written out
+        to disk. e.g. with a `dataset.compute()`.
 
         Parameters
         -----------
         data: Union[Dataset, DataFrameType]
-            Input dataset or dataframe to transform
+            Input Dataset or DataFrame to transform
 
         Returns
         -------
         Dataset or DataFrame
             Transformed Dataset or DataFrame with the workflow graph applied to it
+
+        Raises
+        ------
+        NotImplementedError
+            If passed an unsupoprted data type to transform.
+
         """
         raise NotImplementedError(
-            "Workflow.transform received an unsupported type: {type(dataset)} "
+            f"Workflow.transform received an unsupported type: {type(data)} "
             "Supported types are a `merlin.io.Dataset` or DataFrame (pandas or cudf)"
         )
 

--- a/nvtabular/workflow/workflow.py
+++ b/nvtabular/workflow/workflow.py
@@ -21,7 +21,7 @@ import sys
 import time
 import types
 import warnings
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, Union
 
 import cloudpickle
 import fsspec
@@ -78,7 +78,9 @@ class Workflow:
         self.graph = Graph(output_node)
         self.executor = DaskExecutor(client)
 
-    def transform(self, dataset: Dataset) -> Dataset:
+    def transform(
+        self, dataset: Union[Dataset, "cudf.DataFrame", pd.DataFrame]
+    ) -> Union[Dataset, "cudf.DataFrame", pd.DataFrame]:
         """Transforms the dataset by applying the graph of operators to it. Requires the ``fit``
         method to have already been called, or calculated statistics to be loaded from disk
 

--- a/tests/unit/workflow/test_workflow.py
+++ b/tests/unit/workflow/test_workflow.py
@@ -53,6 +53,15 @@ def test_workflow_double_fit():
         workflow.transform(df_event).to_ddf().compute()
 
 
+def test_workflow_transform_df():
+    df = make_df({"user_session": ["1", "2", "4", "4", "5"]})
+    ops = ["user_session"] >> nvt.ops.Categorify()
+    dataset = nvt.Dataset(df)
+    workflow = nvt.Workflow(ops)
+    workflow.fit(dataset)
+    assert isinstance(workflow.transform(df), type(df))
+
+
 @pytest.mark.parametrize("engine", ["parquet"])
 def test_workflow_fit_op_rename(tmpdir, dataset, engine):
     # NVT


### PR DESCRIPTION
<!--

Thank you for contributing to NVTabular :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->

Enable `Workflow.transform` to be run with a DataFrame type. 