### PR TITLE
update conftest for backwards compat and new api for to parquet call

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -163,8 +163,25 @@ def datasets(tmpdir_factory):
     half = int(len(df) // 2)
 
     # Write Parquet Dataset
-    df.iloc[:half].to_parquet(str(datadir["parquet"].join("dataset-0.parquet")), chunk_size=1000)
-    df.iloc[half:].to_parquet(str(datadir["parquet"].join("dataset-1.parquet")), chunk_size=1000)
+    cudf_version = 0
+    if cudf:
+        cudf_version = cudf.__version__.split(".")[:2]
+        cudf_version = float(".".join(cudf_version))
+
+    if cudf_version > 22.10:
+        df.iloc[:half].to_parquet(
+            str(datadir["parquet"].join("dataset-0.parquet")), row_group_size_rows=5000
+        )
+        df.iloc[half:].to_parquet(
+            str(datadir["parquet"].join("dataset-1.parquet")), row_group_size_rows=5000
+        )
+    else:
+        df.iloc[:half].to_parquet(
+            str(datadir["parquet"].join("dataset-0.parquet")), chunk_size=1000
+        )
+        df.iloc[half:].to_parquet(
+            str(datadir["parquet"].join("dataset-1.parquet")), chunk_size=1000
+        )
 
     # Write CSV Dataset (Leave out categorical column)
     df = df[allcols_csv]  # Set deterministic column order before write


### PR DESCRIPTION
For cudf version 22.10.00+ the to_parquet api has changed. It no longer support the chunk_size call. It was replaced with row_group_size_rows, which can take minimum of 5000 rows. We have updated conftest call to reflect this change while maintaining backwards compatibility. We need this for all future versions. 