### PR TITLE
Use None as default value of `cpu` in test_column_similarity

### DIFF
--- a/tests/unit/ops/test_column_similarity.py
+++ b/tests/unit/ops/test_column_similarity.py
@@ -31,7 +31,7 @@ import nvtabular
 from nvtabular.ops.column_similarity import ColumnSimilarity
 
 
-@pytest.mark.parametrize("cpu", [True, False])
+@pytest.mark.parametrize("cpu", [True, None])
 @pytest.mark.parametrize("cpu_features", [True, False])
 @pytest.mark.parametrize("on_device", [True, False])
 @pytest.mark.parametrize("metric", ["tfidf", "cosine", "inner"])


### PR DESCRIPTION
<!--

Thank you for contributing to NVTabular :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->


Use None as default value of `cpu` in test_column_similarity

_Motivation_: https://github.com/NVIDIA-Merlin/core/pull/243