### PR TITLE
use merlin compat for imports of gpu specific packages

### DIFF
--- a/.github/workflows/cpu-packages.yml
+++ b/.github/workflows/cpu-packages.yml
@@ -6,11 +6,10 @@ on:
     branches: [main]
     tags:
       - v*
-  pull_request:
-    branches: [main]
 
 jobs:
   build-conda:
+    name: Build Conda
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -50,6 +49,7 @@ jobs:
           path: ${{ steps.conda_build.outputs.conda_package }}
 
   build-pypi:
+    name: Build PyPI
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -113,7 +113,7 @@ jobs:
           path: pr/
 
   release-conda:
-    name: Release
+    name: Release Conda
     runs-on: ubuntu-latest
     if: "startsWith(github.ref, 'refs/tags/')"
     needs: [build-conda]
@@ -140,7 +140,7 @@ jobs:
           anaconda -t $ANACONDA_TOKEN upload -u nvidia conda/*.tar.bz2
 
   release-pypi:
-    name: Release
+    name: Release PyPI
     runs-on: ubuntu-latest
     if: "startsWith(github.ref, 'refs/tags/')"
     needs: [build-pypi]

--- a/examples/03-Running-on-multiple-GPUs-or-on-CPU.ipynb
+++ b/examples/03-Running-on-multiple-GPUs-or-on-CPU.ipynb
@@ -142,7 +142,7 @@
     "from dask_cuda import LocalCUDACluster\n",
     "from dask.distributed import Client\n",
     "import nvtabular as nvt\n",
-    "from nvtabular.utils import pynvml_mem_size, device_mem_size\n",
+    "from merlin.core.compat import pynvml_mem_size, device_mem_size\n",
     "\n",
     "dask_workdir = \"test_dask/workdir\""
    ]
@@ -192,7 +192,11 @@
     "part_size = int(part_mem_frac * device_size)\n",
     "\n",
     "# Check if any device memory is already occupied\n",
-    "for dev in visible_devices.split(\",\"):\n",
+    "if NUM_GPUS:\n",
+    "    devices = visible_devices.split(\",\")\n",
+    "else:\n",
+    "    devices = []\n",
+    "for dev in devices:\n",
     "    fmem = pynvml_mem_size(kind=\"free\", index=int(dev))\n",
     "    used = (device_size - fmem) / 1e9\n",
     "    if used > 1.0:\n",
@@ -225,7 +229,7 @@
     }
    ],
    "source": [
-    "if cluster is None:\n",
+    "if cluster is None and NUM_GPUS:\n",
     "    cluster = LocalCUDACluster(\n",
     "        protocol=protocol,\n",
     "        n_workers=len(visible_devices.split(\",\")),\n",
@@ -577,7 +581,10 @@
     }
    ],
    "source": [
-    "client = Client(cluster)\n",
+    "if cluster:\n",
+    "    client = Client(cluster)\n",
+    "else:\n",
+    "    client = Client(processes=False)\n",
     "client.cluster"
    ]
   },
@@ -766,7 +773,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.8.13 64-bit ('3.8.13')",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -780,7 +787,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.8.16"
   },
   "merlin": {
    "containers": [

--- a/nvtabular/framework_utils/tensorflow/tfrecords_to_parquet.py
+++ b/nvtabular/framework_utils/tensorflow/tfrecords_to_parquet.py
@@ -15,12 +15,15 @@
 
 import gc
 
-import cudf
 import tensorflow as tf
-from cudf.core.column.lists import is_list_dtype
-from cudf.io.parquet import ParquetWriter
 from pandas_tfrecords.from_tfrecords import _get_feature_type, read_example
 from tqdm import tqdm
+
+from merlin.core.compat import cudf
+
+if cudf:
+    from cudf.core.column.lists import is_list_dtype
+    from cudf.io.parquet import ParquetWriter
 
 
 def convert_tfrecords_to_parquet(

--- a/nvtabular/inference/triton/data_conversions.py
+++ b/nvtabular/inference/triton/data_conversions.py
@@ -26,12 +26,15 @@
 
 import itertools
 
-import numpy as np
 import pandas as pd
 
-from merlin.core.compat import cp, cudf
+from merlin.core.compat import cudf
+from merlin.core.compat import cupy as cp
+from merlin.core.compat import numpy as np
 from merlin.core.dispatch import build_cudf_list_column, is_list_dtype
 from merlin.dag import Supports
+
+xp = cp or np
 
 
 def convert_format(tensors, kind, target_kind):
@@ -49,7 +52,7 @@ def convert_format(tensors, kind, target_kind):
 
     elif target_kind & Supports.GPU_DICT_ARRAY:
         if kind == Supports.CPU_DICT_ARRAY:
-            return _convert_array(tensors, cp.array), Supports.GPU_DICT_ARRAY
+            return _convert_array(tensors, xp.array), Supports.GPU_DICT_ARRAY
         elif kind == Supports.CPU_DATAFRAME:
             return _pandas_to_array(tensors, False), Supports.GPU_DICT_ARRAY
         elif kind == Supports.GPU_DATAFRAME:
@@ -57,7 +60,7 @@ def convert_format(tensors, kind, target_kind):
 
     elif target_kind & Supports.CPU_DICT_ARRAY:
         if kind == Supports.GPU_DICT_ARRAY:
-            return _convert_array(tensors, cp.asnumpy), Supports.CPU_DICT_ARRAY
+            return _convert_array(tensors, xp.asnumpy), Supports.CPU_DICT_ARRAY
         elif kind == Supports.CPU_DATAFRAME:
             return _pandas_to_array(tensors, True), Supports.CPU_DICT_ARRAY
         elif kind == Supports.GPU_DATAFRAME:
@@ -74,7 +77,7 @@ def convert_format(tensors, kind, target_kind):
         elif kind == Supports.CPU_DICT_ARRAY:
             return _array_to_pandas(tensors), Supports.CPU_DATAFRAME
         elif kind == Supports.GPU_DICT_ARRAY:
-            return _array_to_pandas(_convert_array(tensors, cp.asnumpy)), Supports.CPU_DATAFRAME
+            return _array_to_pandas(_convert_array(tensors, xp.asnumpy)), Supports.CPU_DATAFRAME
 
     raise ValueError("unsupported target for converting tensors", target_kind)
 
@@ -111,7 +114,7 @@ def _array_to_cudf(tensors):
 
 
 def _pandas_to_array(df, cpu=True):
-    array_type = np.array if cpu else cp.array
+    array_type = np.array if cpu else xp.array
 
     output = {}
     for name in df.columns:
@@ -119,13 +122,13 @@ def _pandas_to_array(df, cpu=True):
         if pd.api.types.is_list_like(col.values[0]):
             offsets = pd.Series([0]).append(col.map(len).cumsum()).values
             if not cpu:
-                offsets = cp.array(offsets)
+                offsets = xp.array(offsets)
             values = array_type(list(itertools.chain(*col)))
             output[name] = (values, offsets)
         else:
             values = col.values
             if not cpu:
-                values = cp.array(values)
+                values = xp.array(values)
             output[name] = values
 
     return output

--- a/nvtabular/inference/triton/data_conversions.py
+++ b/nvtabular/inference/triton/data_conversions.py
@@ -26,15 +26,10 @@
 
 import itertools
 
-try:
-    import cudf
-    import cupy as cp
-except ImportError:
-    cudf = cp = None
-
 import numpy as np
 import pandas as pd
 
+from merlin.core.compat import cp, cudf
 from merlin.core.dispatch import build_cudf_list_column, is_list_dtype
 from merlin.dag import Supports
 

--- a/nvtabular/ops/categorify.py
+++ b/nvtabular/ops/categorify.py
@@ -1055,6 +1055,8 @@ def _write_uniques(dfs, base_path, col_selector: ColumnSelector, options: FitOpt
 
         df.to_parquet(path, index=False, compression=None)
     else:
+        if hasattr(df, "convert_dtypes"):
+            df = df.convert_dtypes()
         df_null = type(df)({c: [None] for c in col_selector.names})
         for c in col_selector.names:
             df_null[c] = df_null[c].astype(df[c].dtype)

--- a/nvtabular/ops/column_similarity.py
+++ b/nvtabular/ops/column_similarity.py
@@ -14,10 +14,10 @@
 # limitations under the License.
 #
 import numba
+import pandas as pd
 import scipy.sparse
 
 from merlin.core.compat import cuda, cupy, numpy
-from merlin.core.compat import pandas as pd
 from merlin.core.dispatch import DataFrameType, annotate
 from merlin.schema import Schema, Tags
 from nvtabular.ops.operator import ColumnSelector, Operator

--- a/nvtabular/ops/column_similarity.py
+++ b/nvtabular/ops/column_similarity.py
@@ -13,25 +13,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-try:
-    import cupy
-    import cupy.sparse
-except ImportError:
-    cupy = None
-
 import numba
-import numpy
-import pandas as pd
 import scipy.sparse
 
-try:
-    from cupyx.scipy.sparse import coo_matrix
-except ImportError:
-    from scipy.sparse import coo_matrix
-
+from merlin.core.compat import cuda, cupy, numpy
+from merlin.core.compat import pandas as pd
 from merlin.core.dispatch import DataFrameType, annotate
 from merlin.schema import Schema, Tags
 from nvtabular.ops.operator import ColumnSelector, Operator
+
+if cupy:
+    from cupyx.scipy.sparse import coo_matrix
+else:
+    from scipy.sparse import coo_matrix
 
 
 class ColumnSimilarity(Operator):
@@ -208,15 +202,17 @@ def _row_wise_inner_product_cpu(
         )
 
 
-@numba.cuda.jit
-def _row_wise_inner_product_gpu(
-    a, a_indptr, a_indices, a_data, b, b_indptr, b_indices, b_data, output
-):
-    i = numba.cuda.grid(1)
-    if i < a.size:
-        output[i] = _inner_product_gpu(
-            a[i], a_indptr, a_indices, a_data, b[i], b_indptr, b_indices, b_data
-        )
+if cuda:
+
+    @numba.cuda.jit
+    def _row_wise_inner_product_gpu(
+        a, a_indptr, a_indices, a_data, b, b_indptr, b_indices, b_data, output
+    ):
+        i = numba.cuda.grid(1)
+        if i < a.size:
+            output[i] = _inner_product_gpu(
+                a[i], a_indptr, a_indices, a_data, b[i], b_indptr, b_indices, b_data
+            )
 
 
 def _inner_product(a, a_indptr, a_indices, a_data, b, b_indptr, b_indices, b_data):
@@ -243,7 +239,7 @@ def _inner_product(a, a_indptr, a_indices, a_data, b, b_indptr, b_indices, b_dat
 
 # JIT the _inner_product function to run on both CPU/GPU using numba
 _inner_product_cpu = numba.njit(inline="always")(_inner_product)
-_inner_product_gpu = numba.cuda.jit(device=True, inline=True)(_inner_product)
+_inner_product_gpu = numba.cuda.jit(device=True, inline=True)(_inner_product) if cuda else None
 
 
 def _convert_features(features, metric, on_device):

--- a/nvtabular/ops/join_external.py
+++ b/nvtabular/ops/join_external.py
@@ -15,14 +15,10 @@
 #
 import warnings
 
-try:
-    import cudf
-except ImportError:
-    cudf = None
-
 import dask.dataframe as dd
 import pandas as pd
 
+from merlin.core.compat import cudf
 from merlin.core.dispatch import (
     DataFrameType,
     ExtData,

--- a/nvtabular/utils.py
+++ b/nvtabular/utils.py
@@ -18,7 +18,7 @@
 import warnings
 
 # Re-export classes/modules from the core library for backwards compatibility
-from merlin.core.utils import *  # noqa
+from merlin.core.compat import *  # noqa
 
 warnings.warn(
     "The `nvtabular.utils` module has moved to `merlin.core.utils`. "

--- a/nvtabular/workflow/workflow.py
+++ b/nvtabular/workflow/workflow.py
@@ -27,12 +27,8 @@ from typing import TYPE_CHECKING, Optional
 import cloudpickle
 import fsspec
 
-try:
-    import cudf
-except ImportError:
-    cudf = None
-import pandas as pd
-
+from merlin.core.compat import cudf
+from merlin.core.compat import pandas as pd
 from merlin.dag import Graph
 from merlin.dag.executors import DaskExecutor, LocalExecutor
 from merlin.dag.node import iter_nodes

--- a/nvtabular/workflow/workflow.py
+++ b/nvtabular/workflow/workflow.py
@@ -26,9 +26,9 @@ from typing import TYPE_CHECKING, Optional
 
 import cloudpickle
 import fsspec
+import pandas as pd
 
 from merlin.core.compat import cudf
-from merlin.core.compat import pandas as pd
 from merlin.dag import Graph
 from merlin.dag.executors import DaskExecutor, LocalExecutor
 from merlin.dag.node import iter_nodes

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,10 +25,10 @@ import time
 from pathlib import Path
 
 import dask
+import pandas as pd
 
 from merlin.core.compat import cudf
 from merlin.core.compat import numpy as np
-from merlin.core.compat import pandas as pd
 
 if cudf:
     try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,12 +25,12 @@ import time
 from pathlib import Path
 
 import dask
-import numpy as np
-import pandas as pd
 
-try:
-    import cudf
+from merlin.core.compat import cudf
+from merlin.core.compat import numpy as np
+from merlin.core.compat import pandas as pd
 
+if cudf:
     try:
         import cudf.testing._utils
 
@@ -39,8 +39,7 @@ try:
         import cudf.tests.utils
 
         assert_eq = cudf.tests.utils.assert_eq
-except ImportError:
-    cudf = None
+else:
 
     def assert_eq(a, b, *args, **kwargs):
         if isinstance(a, pd.DataFrame):

--- a/tests/unit/examples/test_02-Advanced-NVTabular-workflow.py
+++ b/tests/unit/examples/test_02-Advanced-NVTabular-workflow.py
@@ -19,7 +19,10 @@ from testbook import testbook
 
 from tests.conftest import REPO_ROOT
 
-pytest.importorskip("cudf")
+from merlin.core.compat import cudf
+
+if not cudf:
+    pytest.mark.skip(reason="could not import cudf successfully")
 pytest.importorskip("tensorflow")
 nest_asyncio.apply()
 

--- a/tests/unit/examples/test_03-Running-on-multiple-GPUs-or-on-CPU.py
+++ b/tests/unit/examples/test_03-Running-on-multiple-GPUs-or-on-CPU.py
@@ -19,7 +19,11 @@ from testbook import testbook
 
 from tests.conftest import REPO_ROOT
 
-pytest.importorskip("dask_cudf")
+from merlin.core.compat import dask_cudf
+
+if not dask_cudf:
+    pytest.mark.skip(reason="could not import dask_cudf successfully")
+
 nest_asyncio.apply()
 
 

--- a/tests/unit/loader/test_torch_dataloader.py
+++ b/tests/unit/loader/test_torch_dataloader.py
@@ -18,6 +18,7 @@ import os
 import shutil
 import time
 
+import pandas as pd
 import pyarrow as pa
 import pytest
 
@@ -26,7 +27,6 @@ import nvtabular.tools.data_gen as datagen
 from merlin.core import dispatch
 from merlin.core.compat import HAS_GPU, cudf
 from merlin.core.compat import numpy as np
-from merlin.core.compat import pandas as pd
 from merlin.core.dispatch import make_df
 from merlin.io import Dataset
 from nvtabular import ColumnSelector, ops

--- a/tests/unit/loader/test_torch_dataloader.py
+++ b/tests/unit/loader/test_torch_dataloader.py
@@ -19,21 +19,15 @@ import shutil
 import time
 
 import pyarrow as pa
-
-from merlin.core.dispatch import HAS_GPU, make_df
-
-try:
-    import cudf
-except ImportError:
-    cudf = None
-
-import numpy as np
-import pandas as pd
 import pytest
 
 import nvtabular as nvt
 import nvtabular.tools.data_gen as datagen
 from merlin.core import dispatch
+from merlin.core.compat import HAS_GPU, cudf
+from merlin.core.compat import numpy as np
+from merlin.core.compat import pandas as pd
+from merlin.core.dispatch import make_df
 from merlin.io import Dataset
 from nvtabular import ColumnSelector, ops
 from tests.conftest import assert_eq, mycols_csv, mycols_pq

--- a/tests/unit/ops/test_categorify.py
+++ b/tests/unit/ops/test_categorify.py
@@ -22,18 +22,16 @@ import pytest
 
 import nvtabular as nvt
 from merlin.core import dispatch
+from merlin.core.compat import HAS_GPU, cudf
 from merlin.core.dispatch import make_df
 from nvtabular import ColumnSelector, ops
 from nvtabular.ops.categorify import get_embedding_sizes
 
-try:
-    import cudf
-
+if cudf:
     _CPU = [True, False]
-    _HAS_GPU = True
-except ImportError:
+else:
     _CPU = [True]
-    _HAS_GPU = False
+_HAS_GPU = HAS_GPU
 
 
 @pytest.mark.parametrize("cpu", _CPU)

--- a/tests/unit/ops/test_drop_low_cardinality.py
+++ b/tests/unit/ops/test_drop_low_cardinality.py
@@ -17,13 +17,12 @@ import pandas as pd
 import pytest
 
 import nvtabular as nvt
+from merlin.core.compat import cudf
 from tests.conftest import assert_eq
 
-try:
-    import cudf
-
+if cudf:
     _CPU = [True, False]
-except ImportError:
+else:
     _CPU = [True]
 
 

--- a/tests/unit/ops/test_groupyby.py
+++ b/tests/unit/ops/test_groupyby.py
@@ -19,14 +19,13 @@ import pandas as pd
 import pytest
 
 import nvtabular as nvt
+from merlin.core.compat import cudf
 from merlin.core.dispatch import make_df
 from nvtabular import ColumnSelector, Schema, Workflow, ops
 
-try:
-    import cudf
-
+if cudf:
     _CPU = [True, False]
-except ImportError:
+else:
     _CPU = [True]
 
 

--- a/tests/unit/ops/test_join.py
+++ b/tests/unit/ops/test_join.py
@@ -18,16 +18,15 @@ import pandas as pd
 import pytest
 
 import nvtabular as nvt
+from merlin.core.compat import HAS_GPU, dask_cudf
 from nvtabular import ops
 
-try:
-    import dask_cudf
-
+if dask_cudf:
     _CPU = [True, False]
-    _HAS_GPU = True
-except ImportError:
+else:
     _CPU = [True]
-    _HAS_GPU = False
+
+_HAS_GPU = HAS_GPU
 
 
 @pytest.mark.parametrize("cpu", _CPU)

--- a/tests/unit/ops/test_ops.py
+++ b/tests/unit/ops/test_ops.py
@@ -21,19 +21,17 @@ import pytest
 
 import nvtabular as nvt
 from merlin.core import dispatch
+from merlin.core.compat import HAS_GPU, cudf, dask_cudf
 from merlin.schema import Tags, TagSet
 from nvtabular import ColumnSelector, ops
 from tests.conftest import assert_eq, mycols_csv, mycols_pq
 
-try:
-    import cudf
-    import dask_cudf
-
+if cudf:
     _CPU = [True, False]
-    _HAS_GPU = True
-except ImportError:
+else:
     _CPU = [True]
-    _HAS_GPU = False
+
+_HAS_GPU = HAS_GPU
 
 
 @pytest.mark.parametrize("gpu_memory_frac", [0.01, 0.1] if _HAS_GPU else [None])

--- a/tests/unit/ops/test_reduce_dtype_size.py
+++ b/tests/unit/ops/test_reduce_dtype_size.py
@@ -18,13 +18,12 @@ import pandas as pd
 import pytest
 
 import nvtabular as nvt
+from merlin.core.compat import cudf
 from tests.conftest import assert_eq
 
-try:
-    import cudf
-
+if cudf:
     _CPU = [True, False]
-except ImportError:
+else:
     _CPU = [True]
 
 

--- a/tests/unit/ops/test_target_encode.py
+++ b/tests/unit/ops/test_target_encode.py
@@ -23,17 +23,16 @@ import pytest
 
 import nvtabular as nvt
 from merlin.core import dispatch
+from merlin.core.compat import HAS_GPU, dask_cudf
 from nvtabular import ColumnSelector, ops
 from tests.conftest import assert_eq
 
-try:
-    import dask_cudf
-
+if dask_cudf:
     _CPU = [True, False]
-    _HAS_GPU = True
-except ImportError:
+else:
     _CPU = [True]
-    _HAS_GPU = False
+
+_HAS_GPU = HAS_GPU
 
 
 @pytest.mark.parametrize("cat_groups", ["Author", [["Author", "Engaging-User"]]])

--- a/tests/unit/test_dask_nvt.py
+++ b/tests/unit/test_dask_nvt.py
@@ -24,13 +24,14 @@ from dask.dataframe import assert_eq
 from dask.dataframe import from_pandas as dd_from_pandas
 from dask.dataframe import read_parquet as dd_read_parquet
 
+from merlin.core.compat import cudf, dask_cudf
 from merlin.core.utils import global_dask_client, set_dask_client
 from merlin.io import Shuffle
 from nvtabular import ColumnSelector, Dataset, Workflow, ops
 from tests.conftest import allcols_csv, mycols_csv, mycols_pq
 
-cudf = pytest.importorskip("cudf")
-dask_cudf = pytest.importorskip("dask_cudf")
+if not cudf:
+    pytest.skip(reason="cudf not successfully imported", allow_module_level=True)
 
 # Dummy operator logic to test stats
 # TODO: Possibly add public API to add

--- a/tests/unit/test_s3.py
+++ b/tests/unit/test_s3.py
@@ -23,11 +23,15 @@ from packaging.version import Version
 
 import nvtabular as nvt
 from merlin.core import dispatch
+from merlin.core.compat import dask_cudf
 from nvtabular import ops
 from tests.conftest import assert_eq, mycols_csv, mycols_pq
 
-dask_cudf = pytest.importorskip("dask_cudf")
-from dask_cudf.io.tests import test_s3  # noqa: E402
+if dask_cudf:
+    from dask_cudf.io.tests import test_s3  # noqa: E402
+else:
+    pytest.skip(reason="dask_cudf not successfully imported", allow_module_level=True)
+
 
 # Import fixtures and context managers from dask_cudf
 s3_base = test_s3.s3_base

--- a/tests/unit/test_tf4rec.py
+++ b/tests/unit/test_tf4rec.py
@@ -1,14 +1,15 @@
 import numpy as np
 
-try:
-    from cudf import to_datetime
-except ImportError:
-    from dask.dataframe import to_datetime
-
 import nvtabular as nvt
+from merlin.core.compat import cudf
 from merlin.core.dispatch import make_df
 from merlin.schema import Schema
 from nvtabular import ColumnSelector
+
+if cudf:
+    from cudf import to_datetime
+else:
+    from dask.dataframe import to_datetime
 
 NUM_ROWS = 10000
 

--- a/tests/unit/test_triton_inference.py
+++ b/tests/unit/test_triton_inference.py
@@ -11,7 +11,8 @@ import pytest
 
 import nvtabular as nvt
 import nvtabular.ops as ops
-from merlin.core.dispatch import HAS_GPU, hash_series, make_df
+from merlin.core.compat import HAS_GPU
+from merlin.core.dispatch import hash_series, make_df
 from merlin.dag import Supports
 from nvtabular import ColumnSelector
 from tests.conftest import assert_eq

--- a/tests/unit/workflow/test_cpu_workflow.py
+++ b/tests/unit/workflow/test_cpu_workflow.py
@@ -8,13 +8,9 @@ import pytest
 from pandas.api.types import is_integer_dtype
 
 import nvtabular as nvt
+from merlin.core.compat import cudf
 from nvtabular import Dataset, Workflow, ops
 from tests.conftest import get_cats
-
-try:
-    import cudf
-except ImportError:
-    cudf = None
 
 
 @pytest.mark.parametrize("engine", ["parquet", "csv", "csv-no-header"])

--- a/tests/unit/workflow/test_workflow.py
+++ b/tests/unit/workflow/test_workflow.py
@@ -20,19 +20,13 @@ import os
 import shutil
 import sys
 
-try:
-    import cudf
-    import dask_cudf
-except ImportError:
-    cudf = None
-    dask_cudf = None
-
 import numpy as np
 import pytest
 from pandas.api.types import is_integer_dtype
 
 import nvtabular as nvt
 from merlin.core import dispatch
+from merlin.core.compat import cudf, dask_cudf
 from merlin.core.dispatch import HAS_GPU, make_df
 from merlin.core.utils import set_dask_client
 from merlin.dag import ColumnSelector, postorder_iter_nodes


### PR DESCRIPTION
This PR enables a user to run our GPU docker container without GPUs and successfully be able to run all tests. Previously we had try catches in a few places in the code for importing GPU specific packages. This PR remediates those try catches because in an environment where you have the package but no GPU you end up getting ccuda.pyx init failure. This is because, the package (i.e. cudf, dask_cudf, rmm) do exist but when they try to access information about GPUs it fails and throws an error something like:
```
collecting ... Traceback (most recent call last):
  File "cuda/_cuda/ccuda.pyx", line 3671, in cuda._cuda.ccuda._cuInit
  File "cuda/_cuda/ccuda.pyx", line 435, in cuda._cuda.ccuda.cuPythonInit
RuntimeError: Failed to dlopen libcuda.so
Exception ignored in: 'cuda._lib.ccudart.utils.cudaPythonGlobal.lazyInitGlobal'
Traceback (most recent call last):
  File "cuda/_cuda/ccuda.pyx", line 3671, in cuda._cuda.ccuda._cuInit
  File "cuda/_cuda/ccuda.pyx", line 435, in cuda._cuda.ccuda.cuPythonInit
RuntimeError: Failed to dlopen libcuda.so
Fatal Python error: Segmentation fault
```
This PR leverages the compat file, and makes it the single point of import for the main packages (cudf, cupy) and it adds a security around it that ensures you can only import those packages if GPUs are detected. So if you find yourself in a scenario where the package is installed but no GPUs are detected you can, now, still safely use the core package. Therefore, we can now run our containers with and without the --gpus=all flag in docker. This was a customer ask and it helps developers when trying to test cpu only environment on a resource that has GPUs.

This PR works in conjunction with https://github.com/NVIDIA-Merlin/core/pull/261