### PR TITLE
Replace nvtabular.utils with merlin.core.compat

### DIFF
--- a/examples/03-Running-on-multiple-GPUs-or-on-CPU.ipynb
+++ b/examples/03-Running-on-multiple-GPUs-or-on-CPU.ipynb
@@ -142,7 +142,7 @@
     "from dask_cuda import LocalCUDACluster\n",
     "from dask.distributed import Client\n",
     "import nvtabular as nvt\n",
-    "from nvtabular.utils import pynvml_mem_size, device_mem_size\n",
+    "from merlin.core.compat import pynvml_mem_size, device_mem_size\n",
     "\n",
     "dask_workdir = \"test_dask/workdir\""
    ]


### PR DESCRIPTION
Same change as https://github.com/NVIDIA-Merlin/Merlin/pull/892.

There was a change in Core that [moved pynvml_mem_size from merlin.core.utils to merlin.core.compat](https://github.com/NVIDIA-Merlin/core/commit/568208cf8598ed6ac982321689e4f67907c96483#diff-71c42f09a533dd2861bcb1c78b2b350190518b1154eb735c50519a090dd8061cR36). This PR replaces `nvtabular.utils` with `merlin.core.compat` in [examples/03-Running-on-multiple-GPUs-or-on-CPU.ipynb](https://github.com/NVIDIA-Merlin/NVTabular/blob/main/examples/03-Running-on-multiple-GPUs-or-on-CPU.ipynb).