### PR TITLE
How to for embedding op with categorify from scratch

### DIFF
--- a/tests/unit/workflow/test_workflow.py
+++ b/tests/unit/workflow/test_workflow.py
@@ -27,7 +27,7 @@ from pandas.api.types import is_integer_dtype
 import nvtabular as nvt
 from merlin.core import dispatch
 from merlin.core.compat import cudf, dask_cudf
-from merlin.core.dispatch import HAS_GPU, create_multihot_col, make_df
+from merlin.core.dispatch import HAS_GPU, create_multihot_col, make_df, make_series
 from merlin.core.utils import set_dask_client
 from merlin.dag import ColumnSelector, postorder_iter_nodes
 from merlin.dataloader.loader_base import LoaderBase as Loader
@@ -749,7 +749,9 @@ def test_embedding_cat_export_import(tmpdir, cpu):
             "string_id": string_ids,
         }
     )
-    training_data["embeddings"] = create_multihot_col([0, 5, 10, 15, 20, 25], np.random.rand(25))
+    training_data["embeddings"] = create_multihot_col(
+        [0, 5, 10, 15, 20, 25], make_series(np.random.rand(25))
+    )
 
     cat_op = nvt.ops.Categorify()
 


### PR DESCRIPTION
This PR adds a test that illustrates how to use pretrained embeddings and how to reuse a categorify operator to either categorify data  to what an item map, or categorify an item map to data that was already fitted in a workflow. It shows how to take that all the way to the dataloader where we can use it to load in embeddings for new data presented.

Requires the following core pr https://github.com/NVIDIA-Merlin/core/pull/337 