### PR TITLE
fix get-cats function to add kwarg usage

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -279,7 +279,7 @@ def get_cats(workflow, col, stat_name="categories", cpu=False):
     # figure out the categorify node from the workflow graph
     cats = [
         cg.op
-        for cg in iter_nodes([workflow.output_node])
+        for cg in iter_nodes([workflow.output_node], flatten_subgraphs=True)
         if isinstance(cg.op, nvtabular.ops.Categorify)
     ]
     if len(cats) != 1:


### PR DESCRIPTION
This PR fixes the get_cats function in conf test so that is uses the newly introduced flatten_subgraphs kwarg. This PR relies on https://github.com/NVIDIA-Merlin/core/pull/345 getting merged first.