### PR TITLE
rename temporary column to something less likely to be used

### DIFF
--- a/cpp/nvtabular/inference/categorify.cc
+++ b/cpp/nvtabular/inference/categorify.cc
@@ -38,7 +38,7 @@ namespace nvtabular
         py::object pandas = py::module_::import("pandas");
         py::object df = pandas.attr("read_parquet")(filename);
         py::object isnull = pandas.attr("isnull");
-        py::array values = df[column_name.c_str()].attr("__labels_tmp");
+        py::array values = df[column_name.c_str()].attr("values");
         auto dtype = values.dtype();
 
         if ((dtype.kind() == 'O') || (dtype.kind() == 'U'))


### PR DESCRIPTION
The internal/temporary column "labels" is a common thing for people to use. Columns with this name will not get categorified. I changed it to `__labels_tmp`.