### PR TITLE
Call `.stop()` on dataloader in `test_dataloader_schema`

### DIFF
--- a/tests/unit/loader/test_tf_dataloader.py
+++ b/tests/unit/loader/test_tf_dataloader.py
@@ -509,3 +509,5 @@ def test_dataloader_schema(tmpdir, df, dataset, batch_size, engine, device):
 
     num_label_cols = batch[1].shape[1] if len(batch[1].shape) > 1 else 1
     assert num_label_cols == len(label_name)
+
+    data_loader.stop()

--- a/tests/unit/loader/test_torch_dataloader.py
+++ b/tests/unit/loader/test_torch_dataloader.py
@@ -526,3 +526,5 @@ def test_dataloader_schema(tmpdir, df, dataset, batch_size, engine, device):
 
     num_label_cols = batch[1].shape[1] if len(batch[1].shape) > 1 else 1
     assert num_label_cols == len(label_name)
+
+    data_loader.stop()


### PR DESCRIPTION
Call `.stop()` on dataloader in `test_dataloader_schema`

This fixes an issue with long-running tests in NVTabular in docker environments.

Without this call to stop. The dataloader background thread is still running, because not all the batches have been iterated through.

This causes problems when combined with the pytest coverage extension `pytest-cov` which seems to cause this thread to not be cleaned up automatically and later tests become very slow due to some resouce contention.

This came up in #1829 which runs the tests on GPU in a different GitHub Actions Runner.