### PR TITLE
Replace deprecated np.bool with bool in FillMisisng operator

### DIFF
--- a/nvtabular/ops/fill.py
+++ b/nvtabular/ops/fill.py
@@ -75,7 +75,7 @@ class FillMissing(Operator):
     def _compute_dtype(self, col_schema, input_schema):
         col_schema = super()._compute_dtype(col_schema, input_schema)
         if col_schema.name.endswith("_filled"):
-            col_schema = col_schema.with_dtype(np.bool)
+            col_schema = col_schema.with_dtype(bool)
         return col_schema
 
     transform.__doc__ = Operator.transform.__doc__
@@ -143,5 +143,5 @@ class FillMedian(StatOperator):
     def _compute_dtype(self, col_schema, input_schema):
         col_schema = super()._compute_dtype(col_schema, input_schema)
         if col_schema.name.endswith("_filled"):
-            col_schema = col_schema.with_dtype(np.bool)
+            col_schema = col_schema.with_dtype(bool)
         return col_schema


### PR DESCRIPTION
Replace deprecated np.bool with bool in FillMisisng operator

Fixes the following error that shows up in `test_fill.py` with newer numpy versions

```
E           AttributeError: module 'numpy' has no attribute 'bool'.
E           `np.bool` was a deprecated alias for the builtin `bool`. To avoid this error in existing code, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here.
E           The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
E               https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations. Did you mean: 'bool_'?
```